### PR TITLE
Proper Exception-throwing Strategy (fixes #12)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "gradle-conventions-plugin"]
-	path = gradle-conventions-plugin
-	url = ../gradle-conventions-plugin

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gradle-conventions-plugin"]
+	path = gradle-conventions-plugin
+	url = ../gradle-conventions-plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,8 @@
 * Full RSA and HMAC Support
 * new interface `Asn1OctetString` to unify both ASN.1 OCTET STREAM classes
 * fix broken `content` property of `Asn1EncapsulatingOctetString`
+* refactor `.derEncoded` property of `Asn1Encodable` interface to function `.encodeToDer()`
+* consistent exception handling behaviour
+  * throw new type `Asn1Exception` for ASN.1-related errors)
+  * add `xxxOrNull()` functions for all encoding/decoding/parsing functions
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ when (val pk = cert.publicKey) {
 
 println("The full certificate is:\n${Json { prettyPrint = true }.encodeToString(cert)}")
 
-println("Re-encoding it produces the same bytes? ${cert.derEncoded contentEquals certBytes}")
+println("Re-encoding it produces the same bytes? ${cert.encodeToDer() contentEquals certBytes}")
 ```
 
 Which produces the following output:
@@ -215,10 +215,10 @@ val tbsCsr = TbsCertificationRequest(
     subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
     publicKey = cryptoPublicKey
 )
-val signed =  /* pass tbsCsr.derEncoded to platform code*/
+val signed =  /* pass tbsCsr.encodeToDer() to platform code*/
 val csr = CertificationRequest(tbsCsr, signatureAlgorithm, signed)
 
-println(csr.derEncoded)
+println(csr.encodeToDer())
 ```
 
 Which results in the following output:
@@ -253,7 +253,7 @@ nodes can be processed as desired. Subclasses of `Asn1Element` reflect this:
 Any complex data structure (such as CSR, public key, certificate, …) implements `Asn1Encodable`, which means you can:
 
 * encapsulate it into an ASN.1 Tree by calling `.encodeToTlv()`
-* directly get a DER-encoded version through the `.derEncoded` lazily evaluated property
+* directly get a DER-encoded byte array through the `.encodetoDer()` function
 
 To also suport going the other way, the companion objects of these complex classes implement `Asn1Decodable`, which
 allows for

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 plugins {
-    id("at.asitplus.gradle.conventions")//version can be omitted for composite builds
+    id("at.asitplus.gradle.conventions") version "1.9.10+20231030" //version can be omitted for composite builds
 }
 group = "at.asitplus.crypto"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 plugins {
-    id("at.asitplus.gradle.conventions") version "1.9.10+20230922" //version can be omitted for composite builds
+    id("at.asitplus.gradle.conventions")//version can be omitted for composite builds
 }
 group = "at.asitplus.crypto"
 

--- a/datatypes-cose/build.gradle.kts
+++ b/datatypes-cose/build.gradle.kts
@@ -11,14 +11,10 @@ plugins {
 
 version = "2.1.0-SNAPSHOT"
 
+exportIosFramework("KmpCryptoCose",  serialization("cbor"), datetime(), project(":datatypes"))
 kotlin {
-    jvm()
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-
     sourceSets {
-        commonMain {
+        val commonMain by getting {
             dependencies {
                 api(project(":datatypes"))
                 api(serialization("cbor"))
@@ -27,11 +23,17 @@ kotlin {
                 implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")
             }
         }
+
+        val jvmMain by getting
+
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("reflect"))
+            }
+        }
+        val jvmTest by getting
     }
 }
-
-
-exportIosFramework("KmpCryptoCose",  serialization("cbor"), datetime(), project(":datatypes"))
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes-cose/build.gradle.kts
+++ b/datatypes-cose/build.gradle.kts
@@ -11,10 +11,14 @@ plugins {
 
 version = "2.1.0-SNAPSHOT"
 
-exportIosFramework("KmpCryptoCose",  serialization("cbor"), datetime(), project(":datatypes"))
 kotlin {
+    jvm()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(project(":datatypes"))
                 api(serialization("cbor"))
@@ -23,17 +27,11 @@ kotlin {
                 implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")
             }
         }
-
-        val jvmMain by getting
-
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("reflect"))
-            }
-        }
-        val jvmTest by getting
     }
 }
+
+
+exportIosFramework("KmpCryptoCose",  serialization("cbor"), datetime(), project(":datatypes"))
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes-cose/build.gradle.kts
+++ b/datatypes-cose/build.gradle.kts
@@ -18,8 +18,6 @@ kotlin {
             dependencies {
                 api(project(":datatypes"))
                 api(serialization("cbor"))
-                api("at.asitplus:kmmresult:${kmmresult}")
-                // implementation("com.squareup.okio:okio:${okio}")
                 implementation(napier())
                 implementation("io.matthewnelson.kotlin-components:encoding-base16:${encoding}")
                 implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")

--- a/datatypes-cose/src/jvmTest/kotlin/CoseKeySerializationTest.kt
+++ b/datatypes-cose/src/jvmTest/kotlin/CoseKeySerializationTest.kt
@@ -27,9 +27,9 @@ class CoseKeySerializationTest : FreeSpec({
                             KeyPairGenerator.getInstance("EC").apply {
                                 initialize(256)
                             }.genKeyPair().public
-                        )!!.toCoseKey(), CryptoPublicKey.fromJcaKey(KeyPairGenerator.getInstance("EC").apply {
+                        )!!.toCoseKey().getOrThrow(), CryptoPublicKey.fromJcaKey(KeyPairGenerator.getInstance("EC").apply {
                             initialize(256)
-                        }.genKeyPair().public)!!.toCoseKey()
+                        }.genKeyPair().public)!!.toCoseKey().getOrThrow()
                     )
                 )
             println(cose.encodeToString(Base16))
@@ -55,7 +55,7 @@ class CoseKeySerializationTest : FreeSpec({
                     keys
                 ) { pubKey ->
 
-                    val coseKey = CryptoPublicKey.fromJcaKey(pubKey)!!.toCoseKey()
+                    val coseKey = CryptoPublicKey.fromJcaKey(pubKey)!!.toCoseKey().getOrThrow()
                     val cose =
                         cborSerializer.encodeToByteArray(coseKey)
                     println(cose.encodeToString(Base16))
@@ -83,7 +83,7 @@ class CoseKeySerializationTest : FreeSpec({
                     keys
                 ) { pubKey ->
 
-                    val coseKey = CryptoPublicKey.fromJcaKey(pubKey)!!.toCoseKey(CoseAlgorithm.RS256)
+                    val coseKey = CryptoPublicKey.fromJcaKey(pubKey)!!.toCoseKey(CoseAlgorithm.RS256).getOrThrow()
                     val cose =
                         cborSerializer.encodeToByteArray(coseKey)
                     println(cose.encodeToString(Base16))

--- a/datatypes-jws/build.gradle.kts
+++ b/datatypes-jws/build.gradle.kts
@@ -1,5 +1,4 @@
 import DatatypeVersions.encoding
-import DatatypeVersions.kmmresult
 import DatatypeVersions.okio
 import at.asitplus.gradle.*
 
@@ -12,10 +11,14 @@ plugins {
 
 version = "2.1.0-SNAPSHOT"
 
-exportIosFramework("KmpCryptoJws",  serialization("json"), datetime(), project(":datatypes"))
 kotlin {
+    jvm()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(project(":datatypes"))
                 implementation("com.squareup.okio:okio:${okio}")
@@ -24,18 +27,10 @@ kotlin {
                 implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")
             }
         }
-
-        val jvmMain by getting
-
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("reflect"))
-            }
-        }
-        val jvmTest by getting
     }
 }
 
+exportIosFramework("KmpCryptoJws", serialization("json"), datetime(), project(":datatypes"))
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes-jws/build.gradle.kts
+++ b/datatypes-jws/build.gradle.kts
@@ -18,7 +18,6 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":datatypes"))
-                api("at.asitplus:kmmresult:${kmmresult}")
                 implementation("com.squareup.okio:okio:${okio}")
                 implementation(napier())
                 implementation("io.matthewnelson.kotlin-components:encoding-base16:${encoding}")

--- a/datatypes-jws/build.gradle.kts
+++ b/datatypes-jws/build.gradle.kts
@@ -1,4 +1,5 @@
 import DatatypeVersions.encoding
+import DatatypeVersions.kmmresult
 import DatatypeVersions.okio
 import at.asitplus.gradle.*
 
@@ -11,14 +12,10 @@ plugins {
 
 version = "2.1.0-SNAPSHOT"
 
+exportIosFramework("KmpCryptoJws",  serialization("json"), datetime(), project(":datatypes"))
 kotlin {
-    jvm()
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-
     sourceSets {
-        commonMain {
+        val commonMain by getting {
             dependencies {
                 api(project(":datatypes"))
                 implementation("com.squareup.okio:okio:${okio}")
@@ -27,10 +24,18 @@ kotlin {
                 implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")
             }
         }
+
+        val jvmMain by getting
+
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("reflect"))
+            }
+        }
+        val jvmTest by getting
     }
 }
 
-exportIosFramework("KmpCryptoJws", serialization("json"), datetime(), project(":datatypes"))
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes/build.gradle.kts
+++ b/datatypes/build.gradle.kts
@@ -12,10 +12,14 @@ plugins {
 version = "2.1.0-SNAPSHOT"
 
 
-exportIosFramework("KmpCrypto", serialization("json"), datetime())
 kotlin {
+    jvm()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api("at.asitplus:kmmresult:${kmmresult}")
                 api(serialization("json"))
@@ -23,24 +27,23 @@ kotlin {
                 implementation("io.matthewnelson.kotlin-components:encoding-base16:${encoding}")
                 implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")
             }
-            val commonTest by getting {
+
+            commonTest {
                 dependencies {
                     implementation(kotest("property"))
-                    implementation(kotlin("reflect"))
                 }
             }
         }
 
-        val jvmMain by getting {
+        jvmMain {
             dependencies {
                 api(bouncycastle("bcpkix"))
             }
         }
-
-        val commonTest by getting
-        val jvmTest by getting
     }
 }
+
+exportIosFramework("KmpCrypto", serialization("json"), datetime())
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes/build.gradle.kts
+++ b/datatypes/build.gradle.kts
@@ -1,3 +1,5 @@
+import DatatypeVersions.encoding
+import DatatypeVersions.kmmresult
 import at.asitplus.gradle.*
 
 plugins {
@@ -10,15 +12,16 @@ plugins {
 version = "2.1.0-SNAPSHOT"
 
 
-exportIosFramework("KmpCrypto",  serialization("json"),datetime())
+exportIosFramework("KmpCrypto", serialization("json"), datetime())
 kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                api("at.asitplus:kmmresult:${kmmresult}")
                 api(serialization("json"))
                 api(datetime())
-                implementation("io.matthewnelson.kotlin-components:encoding-base16:${DatatypeVersions.encoding}")
-                implementation("io.matthewnelson.kotlin-components:encoding-base64:${DatatypeVersions.encoding}")
+                implementation("io.matthewnelson.kotlin-components:encoding-base16:${encoding}")
+                implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")
             }
             val commonTest by getting {
                 dependencies {
@@ -28,7 +31,7 @@ kotlin {
             }
         }
 
-        val jvmMain by getting{
+        val jvmMain by getting {
             dependencies {
                 api(bouncycastle("bcpkix"))
             }

--- a/datatypes/build.gradle.kts
+++ b/datatypes/build.gradle.kts
@@ -12,14 +12,10 @@ plugins {
 version = "2.1.0-SNAPSHOT"
 
 
+exportIosFramework("KmpCrypto", serialization("json"), datetime())
 kotlin {
-    jvm()
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-
     sourceSets {
-        commonMain {
+        val commonMain by getting {
             dependencies {
                 api("at.asitplus:kmmresult:${kmmresult}")
                 api(serialization("json"))
@@ -27,23 +23,24 @@ kotlin {
                 implementation("io.matthewnelson.kotlin-components:encoding-base16:${encoding}")
                 implementation("io.matthewnelson.kotlin-components:encoding-base64:${encoding}")
             }
-
-            commonTest {
+            val commonTest by getting {
                 dependencies {
                     implementation(kotest("property"))
+                    implementation(kotlin("reflect"))
                 }
             }
         }
 
-        jvmMain {
+        val jvmMain by getting {
             dependencies {
                 api(bouncycastle("bcpkix"))
             }
         }
+
+        val commonTest by getting
+        val jvmTest by getting
     }
 }
-
-exportIosFramework("KmpCrypto", serialization("json"), datetime())
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.*
@@ -74,20 +76,20 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             return MultibaseHelper.calcPublicKey(strippedKey)
         }
 
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence): CryptoPublicKey {
-            if (src.children.size != 2) throw IllegalArgumentException("Invalid SPKI Structure!")
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence): CryptoPublicKey = runRethrowing {
+            if (src.children.size != 2) throw Asn1StructuralException("Invalid SPKI Structure!")
             val keyInfo = src.nextChild() as Asn1Sequence
-            if (keyInfo.children.size != 2) throw IllegalArgumentException("Superfluous data in  SPKI!")
+            if (keyInfo.children.size != 2) throw Asn1StructuralException("Superfluous data in  SPKI!")
 
             when (val oid = (keyInfo.nextChild() as Asn1Primitive).readOid()) {
                 Ec.oid -> {
                     val curveOid = (keyInfo.nextChild() as Asn1Primitive).readOid()
                     val curve = EcCurve.entries.find { it.oid == curveOid }
-                        ?: throw IllegalArgumentException("Curve not supported: $curveOid")
+                        ?: throw Asn1Exception("Curve not supported: $curveOid")
 
                     val bitString = (src.nextChild() as Asn1Primitive).readBitString()
-                    if (bitString.rawBytes.first() != Ec.ANSI_PREFIX) throw IllegalArgumentException("EC key not prefixed with 0x04")
+                    if (bitString.rawBytes.first() != Ec.ANSI_PREFIX) throw Asn1Exception("EC key not prefixed with 0x04")
                     val xAndY = bitString.rawBytes.drop(1)
                     val coordLen = curve.coordinateLengthBytes.toInt()
                     val x = xAndY.take(coordLen).toByteArray()
@@ -101,11 +103,11 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
                     val rsaSequence = Asn1Element.parse(bitString.rawBytes) as Asn1Sequence
                     val n = (rsaSequence.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
                     val e = (rsaSequence.nextChild() as Asn1Primitive).readInt()
-                    if (rsaSequence.hasMoreChildren()) throw IllegalArgumentException("Superfluous data in SPKI!")
+                    if (rsaSequence.hasMoreChildren()) throw Asn1StructuralException("Superfluous data in SPKI!")
                     return Rsa(n, e)
                 }
 
-                else -> throw IllegalArgumentException("Unsupported Key Type: $oid")
+                else -> throw Asn1Exception("Unsupported Key Type: $oid")
 
             }
         }
@@ -127,7 +129,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
      */
     @Serializable
     data class Rsa
-    @Throws(Throwable::class)
+    @Throws(IllegalArgumentException::class)
     private constructor(
         /**
          * RSA key size
@@ -150,6 +152,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             if (bits != computed) throw IllegalArgumentException("Provided number of bits (${bits.number}) does not match computed number of bits (${computed.number})")
         }
 
+        @Throws(IllegalArgumentException::class)
         private constructor(params: RsaParams) : this(
             params.size,
             params.n,
@@ -157,9 +160,9 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
         )
 
         /**
-         * @throws Throwable in case of illegal input (odd key size, for example)
+         * @throws IllegalArgumentException in case of illegal input (odd key size, for example)
          */
-        @Throws(Throwable::class)
+        @Throws(IllegalArgumentException::class)
         constructor(n: ByteArray, e: Int) : this(sanitizeRsaInputs(n, e))
 
         override val oid = Rsa.oid
@@ -177,6 +180,8 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
 
             companion object : Identifiable {
                 fun of(numBits: UInt) = entries.find { it.number == numBits }
+
+                @Throws(IllegalArgumentException::class)
                 fun of(n: ByteArray): Size {
                     val nTruncSize = n.dropWhile { it == 0.toByte() }.size
                     return entries.find { nTruncSize == (it.number.toInt() / 8) }
@@ -224,14 +229,14 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             /**
              * decodes a PKCS#1-encoded RSA key
              *
-             * @throws Throwable all sorts of exceptions on invalid input
+             * @throws Asn1Exception all sorts of exceptions on invalid input
              */
-            @Throws(Throwable::class)
-            fun fromPKCS1encoded(input: ByteArray): Rsa {
+            @Throws(Asn1Exception::class)
+            fun fromPKCS1encoded(input: ByteArray): Rsa = runRethrowing {
                 val conv = Asn1Element.parse(input) as Asn1Sequence
                 val n = (conv.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
                 val e = (conv.nextChild() as Asn1Primitive).readInt()
-                if (conv.hasMoreChildren()) throw IllegalArgumentException("Superfluous bytes")
+                if (conv.hasMoreChildren()) throw Asn1StructuralException("Superfluous bytes")
                 return Rsa(Size.of(n), n, e)
             }
 
@@ -279,7 +284,6 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             /**
              * Decodes a key from the provided parameters
              */
-            @Throws(Throwable::class)
             fun fromCoordinates(curve: EcCurve, x: ByteArray, y: ByteArray): Ec =
                 Ec(curve = curve, x = x, y = y)
 
@@ -326,5 +330,6 @@ private val RsaParams.size get() = third
  * This function lives here and returns a typealiased Triple to allow for constructor chaining.
  * If we were to change the primary constructor, we'd need to write a custom serializer
  */
+@Throws(IllegalArgumentException::class)
 private fun sanitizeRsaInputs(n: ByteArray, e: Int): RsaParams = n.dropWhile { it == 0.toByte() }.toByteArray()
     .let { Triple(byteArrayOf(0, *it), e, CryptoPublicKey.Rsa.Size.of(it)) }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/EcCurve.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/EcCurve.kt
@@ -5,6 +5,7 @@ import at.asitplus.crypto.datatypes.asn1.KnownOIDs
 import at.asitplus.crypto.datatypes.asn1.ObjectIdentifier
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -45,7 +46,7 @@ object EcCurveSerializer : KSerializer<EcCurve> {
     override fun deserialize(decoder: Decoder): EcCurve {
         val decoded = decoder.decodeString()
         return EcCurve.entries.firstOrNull { it.jwkName == decoded }
-            ?: throw Throwable("Unsupported EC Curve Type $decoded")
+            ?: throw SerializationException("Unsupported EC Curve Type $decoded")
     }
 
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/JwsAlgorithm.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/JwsAlgorithm.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.*
@@ -105,37 +107,40 @@ enum class JwsAlgorithm(val identifier: String, override val oid: ObjectIdentifi
 
     companion object : Asn1Decodable<Asn1Sequence, JwsAlgorithm> {
 
-        @Throws(Throwable::class)
-        private fun fromOid(oid: ObjectIdentifier) = entries.first { it.oid == oid }
+        @Throws(Asn1OidException::class)
+        private fun fromOid(oid: ObjectIdentifier) = runCatching { entries.first { it.oid == oid } }.getOrElse {
+            throw Asn1OidException("Unsupported OID: $oid", oid)
+        }
 
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence): JwsAlgorithm {
-            return when (val oid = (src.nextChild() as Asn1Primitive).readOid()) {
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence): JwsAlgorithm = runRethrowing {
+            when (val oid = (src.nextChild() as Asn1Primitive).readOid()) {
                 ES512.oid, ES384.oid, ES256.oid -> JwsAlgorithm.fromOid(oid)
 
                 NON_JWS_SHA1_WITH_RSA.oid -> NON_JWS_SHA1_WITH_RSA
                 RS256.oid, RS384.oid, RS512.oid,
                 HS256.oid, HS384.oid, HS512.oid -> JwsAlgorithm.fromOid(oid).also {
-                    if (src.nextChild().tag != BERTags.NULL) throw IllegalArgumentException("RSA Params not allowed")
+                    val tag = src.nextChild().tag
+                    if (tag != BERTags.NULL)
+                        throw Asn1TagMismatchException(BERTags.NULL, tag, "RSA Params not allowed.")
                 }
 
                 PS256.oid, PS384.oid, PS512.oid -> parsePssParams(src)
-                else -> throw IllegalArgumentException("Unsupported algorithm oid: $oid")
+                else -> throw Asn1Exception("Unsupported algorithm oid: $oid")
             }
-
         }
 
-
-        private fun parsePssParams(src: Asn1Sequence): JwsAlgorithm {
+        @Throws(Asn1Exception::class)
+        private fun parsePssParams(src: Asn1Sequence): JwsAlgorithm = runRethrowing {
             val seq = src.nextChild() as Asn1Sequence
-            val first = (seq.nextChild() as Asn1Tagged).verify(0.toUByte()).single() as Asn1Sequence
+            val first = (seq.nextChild() as Asn1Tagged).verifyTag(0.toUByte()).single() as Asn1Sequence
 
             val sigAlg = (first.nextChild() as Asn1Primitive).readOid()
-            if (first.nextChild().tag != BERTags.NULL) throw IllegalArgumentException(
-                "PSS Params not supported yet"
-            )
+            val tag = first.nextChild().tag
+            if (tag != BERTags.NULL)
+                throw Asn1TagMismatchException(BERTags.NULL, tag, "PSS Params not supported yet")
 
-            val second = (seq.nextChild() as Asn1Tagged).verify(1.toUByte()).single() as Asn1Sequence
+            val second = (seq.nextChild() as Asn1Tagged).verifyTag(1.toUByte()).single() as Asn1Sequence
             val mgf = (second.nextChild() as Asn1Primitive).readOid()
             if (mgf != KnownOIDs.`pkcs1-MGF`) throw IllegalArgumentException("Illegal OID: $mgf")
             val inner = second.nextChild() as Asn1Sequence
@@ -147,7 +152,7 @@ enum class JwsAlgorithm(val identifier: String, override val oid: ObjectIdentifi
             )
 
 
-            val last = (seq.nextChild() as Asn1Tagged).verify(2.toUByte()).single() as Asn1Primitive
+            val last = (seq.nextChild() as Asn1Tagged).verifyTag(2.toUByte()).single() as Asn1Primitive
             val saltLen = last.readInt()
 
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/JwsAlgorithm.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/JwsAlgorithm.kt
@@ -105,8 +105,10 @@ enum class JwsAlgorithm(val identifier: String, override val oid: ObjectIdentifi
 
     companion object : Asn1Decodable<Asn1Sequence, JwsAlgorithm> {
 
+        @Throws(Throwable::class)
         private fun fromOid(oid: ObjectIdentifier) = entries.first { it.oid == oid }
 
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Sequence): JwsAlgorithm {
             return when (val oid = (src.nextChild() as Asn1Primitive).readOid()) {
                 ES512.oid, ES384.oid, ES256.oid -> JwsAlgorithm.fromOid(oid)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1BitString.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1BitString.kt
@@ -7,7 +7,7 @@ import at.asitplus.crypto.datatypes.io.BitSet
  */
 class Asn1BitString private constructor(
     /**
-     * Number fo bits needed to pad the bit string to a byte boundary
+     * Number of bits needed to pad the bit string to a byte boundary
      */
     val numPaddingBits: Byte,
 
@@ -80,14 +80,19 @@ class Asn1BitString private constructor(
             return ((8 - (bitSet.length() % 8)) % 8).toByte() to rawBytes
         }
 
+        @Throws(Asn1Exception::class)
         private fun decode(src: Asn1Primitive, tagOverride: UByte? = null): Asn1BitString {
-            if (src.tag != tagOverride ?: BERTags.BIT_STRING) throw IllegalArgumentException("Expected tag ${tagOverride ?: BERTags.BIT_STRING}, is: ${src.tag}")
+            if (src.tag != (tagOverride ?: BERTags.BIT_STRING))
+                throw Asn1TagMismatchException(tagOverride ?: BERTags.BIT_STRING, src.tag)
             if (src.length == 0) return Asn1BitString(0, byteArrayOf())
+            if (src.content.first() > 7) throw Asn1Exception("Number of padding bits < 7")
             return Asn1BitString(src.content[0], src.content.sliceArray(1..<src.content.size))
         }
 
+        @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive) = decodeFromTlv(src, null)
 
+        @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive, tagOverride: UByte?) = decode(src, tagOverride)
     }
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
@@ -151,10 +151,16 @@ sealed class Asn1Structure(tag: UByte, children: List<Asn1Element>?) :
 
     /**
      * Returns the next child held by this structure. Useful for iterating over its children when parsing complex structures.
-     * @throws [IndexOutOfBoundsException] if no more children are available
+     * @throws [Asn1StructuralException] if no more children are available
      */
-    @Throws(IndexOutOfBoundsException::class)
-    fun nextChild() = children[index++]
+    @Throws(Asn1StructuralException::class)
+    fun nextChild() =
+        runCatching { children[index++] }.getOrElse { throw Asn1StructuralException("No more content left") }
+
+    /**
+     * Exception-free version of [nextChild]
+     */
+    fun nextChildOrNull() = runCatching { nextChild() }.getOrNull()
 
     /**
      * Returns `true` if more children can be retrieved by [nextChild]. `false` otherwise
@@ -162,7 +168,7 @@ sealed class Asn1Structure(tag: UByte, children: List<Asn1Element>?) :
     fun hasMoreChildren() = children.size > index
 
     /**
-     * Returns the current child (useful when iterating over this structures children)
+     * Returns the current child (useful when iterating over this structure's children)
      */
     fun peek() = if (!hasMoreChildren()) null else children[index]
 }
@@ -175,13 +181,13 @@ class Asn1Tagged
  * @param tag the ASN.1 Tag to be used (assumed to have [BERTags.CONSTRUCTED] and [BERTags.TAGGED] bits set)
  * @param children the child nodes to be contained in this tag
  *
- * @throws IllegalArgumentException is [tag] does not have [BERTags.CONSTRUCTED] and [BERTags.TAGGED] bits set
+ * @throws Asn1Exception is [tag] does not have [BERTags.CONSTRUCTED] and [BERTags.TAGGED] bits set
  */
-@Throws(IllegalArgumentException::class)
+@Throws(Asn1Exception::class)
 internal constructor(tag: UByte, children: List<Asn1Element>) : Asn1Structure(tag, children) {
 
     init {
-        if (!tag.isExplicitTag) throw IllegalArgumentException(
+        if (!tag.isExplicitTag) throw Asn1Exception(
             "Tag 0x${byteArrayOf(tag.toByte()).encodeToString(Base16)} " +
                     "is not an explicit tag"
         )
@@ -195,7 +201,7 @@ internal constructor(tag: UByte, children: List<Asn1Element>) : Asn1Structure(ta
  * ASN.1 SEQUENCE 0x30 ([DERTags.DER_SEQUENCE])
  * @param children the elements to put into this sequence
  */
-class Asn1Sequence(children: List<Asn1Element>) : Asn1Structure(DERTags.DER_SEQUENCE, children) {
+class Asn1Sequence internal constructor(children: List<Asn1Element>) : Asn1Structure(DERTags.DER_SEQUENCE, children) {
     override fun toString() = "Sequence" + super.toString()
     override fun prettyPrint(indent: Int) = (" " * indent) + "Sequence" + super.prettyPrint(indent + 2)
 }
@@ -237,15 +243,28 @@ class Asn1PrimitiveOctetString(content: ByteArray) : Asn1Primitive(BERTags.OCTET
 
 
 /**
- * ASN.1 SET 0x30 ([DERTags.DER_SET])
- * @param children the elements to put into this set
+ * ASN.1 SET 0x31 ([DERTags.DER_SET])
+ * @param children the elements to put into this set. will be automatically sorted by tag
  */
-class Asn1Set(children: List<Asn1Element>?) : Asn1Structure(DERTags.DER_SET, children) {
+open class Asn1Set internal constructor(children: List<Asn1Element>?) :
+    Asn1Structure(DERTags.DER_SET, children?.sortedBy { it.tag }) {
     override fun toString() = "Set" + super.toString()
 
 
     override fun prettyPrint(indent: Int) = (" " * indent) + "Set" + super.prettyPrint(indent + 2)
 }
+
+/**
+ * ASN.1 SET OF 0x31 ([DERTags.DER_SET])
+ * @param children the elements to put into this set. will be automatically checked to have the same tag and sorted by value
+ * @throws Asn1Exception if children are using different tags
+ */
+class Asn1SetOf @Throws(Asn1Exception::class) internal constructor(children: List<Asn1Element>?) :
+    Asn1Set(children?.let {
+        if (it.any { elem -> elem.tag != it.first().tag }) throw Asn1Exception("SET OF must only contain elements of the same tag")
+        it.sortedBy { it.derEncoded.encodeToString(Base16) } //TODO this is inefficient
+
+    })
 
 /**
  * ASN.1 primitive. Hold o children, but [content] under [tag]
@@ -324,6 +343,7 @@ data class TLV(val tag: UByte, val content: ByteArray) {
     }
 }
 
+@Throws(IllegalArgumentException::class)
 private fun Int.encodeLength(): ByteArray {
     if (this < 128) {
         return byteArrayOf(this.toByte())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
@@ -178,7 +178,7 @@ class Asn1Tagged
  * @throws IllegalArgumentException is [tag] does not have [BERTags.CONSTRUCTED] and [BERTags.TAGGED] bits set
  */
 @Throws(IllegalArgumentException::class)
-constructor(tag: UByte, children: List<Asn1Element>) : Asn1Structure(tag, children) {
+internal constructor(tag: UByte, children: List<Asn1Element>) : Asn1Structure(tag, children) {
 
     init {
         if (!tag.isExplicitTag) throw IllegalArgumentException(

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
@@ -10,16 +10,16 @@ interface Asn1Encodable<A : Asn1Element> {
 
     /**
      * Encodes the implementing object into an [A]
+     * @throws Asn1Exception in case an illegal ASN.1 Object was to be constructed
      */
     @Throws(Asn1Exception::class)
     fun encodeToTlv(): A
 
     /**
-     * Convenience property to directly get the DER-encoded representation of the implementing object
+     * Convenience function to directly get the DER-encoded representation of the implementing object
      */
-
-    @Transient
-    val derEncoded @Throws(Asn1Exception::class) get() = encodeToTlv().derEncoded
+    @Throws(Asn1Exception::class)
+    fun encodeToDER()  = encodeToTlv().derEncoded
 }
 
 /**

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.asn1
 
+import at.asitplus.crypto.datatypes.asn1.DERTags.toImplicitTag
 import kotlinx.serialization.Transient
 
 /**
@@ -32,26 +33,48 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
     fun decodeFromTlv(src: A): T
 
     /**
+     * Exception-free version of [decodeFromTlv]
+     */
+    fun decodeFromTlvOrNull(src: A) = runCatching { decodeFromTlv(src) }.getOrNull()
+
+    /**
      * Convenience method, directly DER-decoding a byte array to [T]
      * @throws [Throwable] of various sorts if invalid data is provided
      */
     @Throws(Throwable::class)
     fun derDecode(src: ByteArray): T = decodeFromTlv(Asn1Element.parse(src) as A)
+
+    /**
+     * Exception-free version of [derDecode]
+     */
+    fun derDecodeOrNull(src: ByteArray) = runCatching { derDecode(src) }.getOrNull()
 }
 
-interface Asn1TagVerifyingDecodable<T:Asn1Encodable<Asn1Primitive>> : Asn1Decodable<Asn1Primitive, T> {
+interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> : Asn1Decodable<Asn1Primitive, T> {
 
     /**
      * Same as [Asn1Decodable.decodeFromTlv], but allows overriding the tag, should the implementing class verify it.
-     * Useful for implicit tagging.
+     * Useful for implicit tagging, in which case you will want to call [at.asitplus.crypto.datatypes.asn1.DERTags.toImplicitTag] on [tagOverride].
      */
     @Throws(Throwable::class)
     fun decodeFromTlv(src: Asn1Primitive, tagOverride: UByte?): T
+
+    /**
+     * Exception-free version of [decodeFromTlv]
+     */
+    fun decodeFromTlvOrNull(src: Asn1Primitive, tagOverride: UByte?) =
+        runCatching { decodeFromTlv(src, tagOverride) }.getOrNull()
 
     /**
      * Same as [Asn1Decodable.derDecode], but allows overriding the tag, should the implementing class verify it.
      * Useful for implicit tagging.
      */
     @Throws(Throwable::class)
-    fun derDecode(src: ByteArray, tagOverride: UByte?): T = decodeFromTlv(Asn1Element.parse(src) as Asn1Primitive, tagOverride)
+    fun derDecode(src: ByteArray, tagOverride: UByte?): T =
+        decodeFromTlv(Asn1Element.parse(src) as Asn1Primitive, tagOverride)
+
+    /**
+     * Exception-free version of [derDecode]
+     */
+    fun derDecodeOrNull(src: ByteArray, tagOverride: UByte?) = runCatching { derDecode(src, tagOverride) }.getOrNull()
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
@@ -1,7 +1,6 @@
 package at.asitplus.crypto.datatypes.asn1
 
 import at.asitplus.crypto.datatypes.asn1.DERTags.toImplicitTag
-import kotlinx.serialization.Transient
 
 /**
  * Interface providing methods to encode to ASN.1
@@ -16,10 +15,20 @@ interface Asn1Encodable<A : Asn1Element> {
     fun encodeToTlv(): A
 
     /**
+     * Exception-free version of [encodeToTlv]
+     */
+    fun encodeToTlvOrNull() = runCatching { encodeToTlv() }.getOrNull()
+
+    /**
      * Convenience function to directly get the DER-encoded representation of the implementing object
      */
     @Throws(Asn1Exception::class)
-    fun encodeToDER()  = encodeToTlv().derEncoded
+    fun encodeToDer() = encodeToTlv().derEncoded
+
+    /**
+     * Exception-free version of [encodeToDer]
+     */
+    fun encodeRoDerOrNull() = runCatching { encodeToDer() }.getOrNull()
 }
 
 /**

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
@@ -11,13 +11,15 @@ interface Asn1Encodable<A : Asn1Element> {
     /**
      * Encodes the implementing object into an [A]
      */
+    @Throws(Asn1Exception::class)
     fun encodeToTlv(): A
 
     /**
      * Convenience property to directly get the DER-encoded representation of the implementing object
      */
+
     @Transient
-    val derEncoded get() = encodeToTlv().derEncoded
+    val derEncoded @Throws(Asn1Exception::class) get() = encodeToTlv().derEncoded
 }
 
 /**
@@ -27,9 +29,9 @@ interface Asn1Encodable<A : Asn1Element> {
 interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
     /**
      * Processes an [A], parsing it into an instance of [T]
-     * @throws [Throwable] of various sorts if invalid data is provided
+     * @throws Asn1Exception if invalid data is provided
      */
-    @Throws(Throwable::class)
+    @Throws(Asn1Exception::class)
     fun decodeFromTlv(src: A): T
 
     /**
@@ -39,9 +41,9 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
 
     /**
      * Convenience method, directly DER-decoding a byte array to [T]
-     * @throws [Throwable] of various sorts if invalid data is provided
+     * @throws Asn1Exception if invalid data is provided
      */
-    @Throws(Throwable::class)
+    @Throws(Asn1Exception::class)
     fun derDecode(src: ByteArray): T = decodeFromTlv(Asn1Element.parse(src) as A)
 
     /**
@@ -55,8 +57,9 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> : Asn1Deco
     /**
      * Same as [Asn1Decodable.decodeFromTlv], but allows overriding the tag, should the implementing class verify it.
      * Useful for implicit tagging, in which case you will want to call [at.asitplus.crypto.datatypes.asn1.DERTags.toImplicitTag] on [tagOverride].
+     * @throws Asn1Exception
      */
-    @Throws(Throwable::class)
+    @Throws(Asn1Exception::class)
     fun decodeFromTlv(src: Asn1Primitive, tagOverride: UByte?): T
 
     /**
@@ -69,7 +72,7 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> : Asn1Deco
      * Same as [Asn1Decodable.derDecode], but allows overriding the tag, should the implementing class verify it.
      * Useful for implicit tagging.
      */
-    @Throws(Throwable::class)
+    @Throws(Asn1Exception::class)
     fun derDecode(src: ByteArray, tagOverride: UByte?): T =
         decodeFromTlv(Asn1Element.parse(src) as Asn1Primitive, tagOverride)
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
@@ -42,14 +42,14 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
 interface Asn1TagVerifyingDecodable<T:Asn1Encodable<Asn1Primitive>> : Asn1Decodable<Asn1Primitive, T> {
 
     /**
-     * Same as [Asn1Decodable.decodeFromTlv], but allows overriding the tag, shoudl the implementing class verify it.
+     * Same as [Asn1Decodable.decodeFromTlv], but allows overriding the tag, should the implementing class verify it.
      * Useful for implicit tagging.
      */
     @Throws(Throwable::class)
     fun decodeFromTlv(src: Asn1Primitive, tagOverride: UByte?): T
 
     /**
-     * Same as [Asn1Decodable.derDecode], but allows overriding the tag, shoudl the implementing class verify it.
+     * Same as [Asn1Decodable.derDecode], but allows overriding the tag, should the implementing class verify it.
      * Useful for implicit tagging.
      */
     @Throws(Throwable::class)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoder.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoder.kt
@@ -168,7 +168,7 @@ class Asn1TreeBuilder {
         else Asn1Set(seq.elements.let {
             if (type == CollectionType.SET) it.sortedBy { it.tag }
             else {
-                if (it.any { elem -> elem.tag != it.first().tag }) throw IllegalArgumentException("SET_OF must only contain elements of the same tag")
+                if (it.any { elem -> elem.tag != it.first().tag }) throw IllegalArgumentException("SET OF must only contain elements of the same tag")
                 it.sortedBy { it.derEncoded.encodeToString(Base16) } //TODO this is inefficient
             }
         })
@@ -237,6 +237,8 @@ class Asn1TreeBuilder {
      *     }
      *   }
      *  ```
+     *
+     *  @throws IllegalArgumentException if children have different tags
      */
     fun setOf(init: Asn1TreeBuilder.() -> Unit) = nest(CollectionType.SET_OF, init)
 
@@ -321,6 +323,27 @@ fun asn1SetOf(root: Asn1TreeBuilder.() -> Unit): Asn1Set {
     val seq = Asn1TreeBuilder()
     seq.root()
     return Asn1Set(seq.elements)
+}
+
+/**
+ * Creates a new EXPLICITLY TAGGED ASN.1 structure as [Asn1Tagged] using [tag].
+ *
+ * * **NOTE:** automatically calls [at.asitplus.crypto.datatypes.asn1.DERTags.toExplicitTag] on [tag]
+ *
+ * Use as follows:
+ *
+ * ```kotlin
+ * asn1Tagged(2u) {
+ *   printableString("World World")
+ *   asn1Null()
+ *   int(1337)
+ * }
+ *  ```
+ */
+fun asn1Tagged(tag:UByte, root: Asn1TreeBuilder.() -> Unit): Asn1Tagged {
+    val seq = Asn1TreeBuilder()
+    seq.root()
+    return Asn1Tagged(tag.toExplicitTag(),seq.elements)
 }
 
 /**

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
@@ -1,0 +1,20 @@
+package at.asitplus.crypto.datatypes.asn1
+
+open class Asn1Exception(message: String?, cause: Throwable?) : Throwable(message, cause) {
+    constructor(message: String) : this(message, null)
+    constructor(throwable: Throwable) : this(null, throwable)
+}
+
+class Asn1TagMismatchException(val expected: UByte, val actual: UByte, detailedMessage: String? = null) :
+    Asn1Exception((detailedMessage?.let { "$it " } ?: "") + "Expected tag $expected, is: $actual")
+
+class Asn1StructuralException(message: String) : Asn1Exception(message)
+
+class Asn1OidException(message: String, val oid: ObjectIdentifier) : Asn1Exception(message)
+
+/**
+ * Runs [block] inside [runCatching] and encapsulates any thrown exception in an [Asn1Exception] unless it already is one
+ */
+@Throws(Asn1Exception::class)
+inline fun <reified R> runRethrowing(block: () -> R) =
+    runCatching(block).getOrElse { throw if (it is Asn1Exception) it else Asn1Exception(it.message, it) }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Reader.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Reader.kt
@@ -238,7 +238,7 @@ private fun Instant.Companion.decodeGeneralizedTimeFromDer(input: ByteArray): In
  * @throws Asn1Exception if the byte array is too long to be parsed to an int (note that only rudimentary checking happens)
  */
 @Throws(Asn1Exception::class)
-internal fun Int.Companion.decodeFromDer(input: ByteArray): Int = runRethrowing {
+fun Int.Companion.decodeFromDer(input: ByteArray): Int = runRethrowing {
     if (input.size > 5) throw IllegalArgumentException("Absolute value too large!")
     return Long.decodeFromDer(input).toInt()
 }
@@ -247,7 +247,7 @@ internal fun Int.Companion.decodeFromDer(input: ByteArray): Int = runRethrowing 
  * @throws IllegalArgumentException if the byte array is too long to be parsed to a long (note that only rudimentary checking happens)
  */
 @Throws(Asn1Exception::class)
-internal fun Long.Companion.decodeFromDer(bytes: ByteArray): Long = runRethrowing {
+fun Long.Companion.decodeFromDer(bytes: ByteArray): Long = runRethrowing {
     val input = if (bytes.size == 8) bytes else {
         if (bytes.size > 9) throw IllegalArgumentException("Absolute value too large!")
         val padding = if (bytes.first() and 0x80.toByte() != 0.toByte()) 0xFF.toByte() else 0x00.toByte()

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1String.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1String.kt
@@ -68,15 +68,15 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
 
     /**
      * PRINTABLE STRING (checked)
-     * @throws IllegalArgumentException if illegal characters are provided
+     * @throws Asn1Exception if illegal characters are provided
      */
     @Serializable
     @SerialName("PrintableString")
 
-    class Printable @Throws(IllegalArgumentException::class) constructor(override val value: String) : Asn1String() {
+    class Printable @Throws(Asn1Exception::class) constructor(override val value: String) : Asn1String() {
         init {
             Regex("[a-zA-Z0-9 '()+,-./:=?]*").matchEntire(value)
-                ?: throw IllegalArgumentException("Input contains invalid chars: '$value'")
+                ?: throw Asn1Exception("Input contains invalid chars: '$value'")
         }
 
         override val tag = BERTags.PRINTABLE_STRING
@@ -84,14 +84,14 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
 
     /**
      * NUMERIC STRING (checked)
-     * @throws IllegalArgumentException if illegal characters are provided
+     * @throws Asn1Exception if illegal characters are provided
      */
     @Serializable
     @SerialName("NumericString")
-    class Numeric @Throws(IllegalArgumentException::class) constructor(override val value: String) : Asn1String() {
+    class Numeric @Throws(Asn1Exception::class) constructor(override val value: String) : Asn1String() {
         init {
             Regex("[0-9 ]*").matchEntire(value)
-                ?: throw IllegalArgumentException("Input contains invalid chars: '$value'")
+                ?: throw Asn1Exception("Input contains invalid chars: '$value'")
         }
 
         override val tag = BERTags.NUMERIC_STRING
@@ -100,6 +100,8 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     override fun encodeToTlv() = Asn1Primitive(tag, value.encodeToByteArray())
 
     companion object : Asn1Decodable<Asn1Primitive, Asn1String> {
+
+        @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive): Asn1String = src.readString()
     }
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1String.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1String.kt
@@ -68,10 +68,12 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
 
     /**
      * PRINTABLE STRING (checked)
+     * @throws IllegalArgumentException if illegal characters are provided
      */
     @Serializable
     @SerialName("PrintableString")
-    class Printable(override val value: String) : Asn1String() {
+
+    class Printable @Throws(IllegalArgumentException::class) constructor(override val value: String) : Asn1String() {
         init {
             Regex("[a-zA-Z0-9 '()+,-./:=?]*").matchEntire(value)
                 ?: throw IllegalArgumentException("Input contains invalid chars: '$value'")
@@ -82,10 +84,11 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
 
     /**
      * NUMERIC STRING (checked)
+     * @throws IllegalArgumentException if illegal characters are provided
      */
     @Serializable
     @SerialName("NumericString")
-    class Numeric(override val value: String) : Asn1String() {
+    class Numeric @Throws(IllegalArgumentException::class) constructor(override val value: String) : Asn1String() {
         init {
             Regex("[0-9 ]*").matchEntire(value)
                 ?: throw IllegalArgumentException("Input contains invalid chars: '$value'")

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
@@ -29,6 +29,8 @@ class Asn1Time(val instant: Instant, formatOverride: Format? = null) : Asn1Encod
 
     companion object : Asn1Decodable<Asn1Primitive, Asn1Time> {
         private val THRESHOLD_GENERALIZED_TIME = Instant.parse("2050-01-01T00:00:00Z")
+
+        @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive) =
             Asn1Time(src.readInstant(), if (src.tag == BERTags.UTC_TIME) Format.UTC else Format.GENERALIZED)
     }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/BERTags.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/BERTags.kt
@@ -62,9 +62,14 @@ object DERTags {
     val UByte.isExplicitTag get() = ((this and BERTags.CONSTRUCTED) != 0.toUByte()) && ((this and BERTags.TAGGED) != 0.toUByte())
 
     fun UInt.toExplicitTag() = toUByte().toExplicitTag()
-    fun UInt.toImplicitTag() = toUByte().toImplicitTag()
-    fun UByte.toImplicitTag() =
+
+    @Throws(Asn1Exception::class)
+    fun UInt.toImplicitTag() = runRethrowing { toUByte().toImplicitTag() }
+
+    @Throws(Asn1Exception::class)
+    fun UByte.toImplicitTag() = runRethrowing {
         if (isContainer()) throw IllegalArgumentException("Implicit tag $this would result in CONSTRUCTED bit set") else BERTags.TAGGED or this
+    }
 
     fun UByte.isContainer() = this and BERTags.CONSTRUCTED != 0.toUByte()
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/KnownOIDs.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/KnownOIDs.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package at.asitplus.crypto.datatypes.asn1
 
 //Converted from Peter Gutmann's dumpasn1

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/ObjectIdentifier.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/ObjectIdentifier.kt
@@ -20,7 +20,7 @@ import kotlin.math.ceil
  */
 @ExperimentalUnsignedTypes
 @Serializable(with = ObjectIdSerializer::class)
-class ObjectIdentifier(@Transient vararg val nodes: UInt) : Asn1Encodable<Asn1Primitive> {
+class ObjectIdentifier  @Throws(IllegalArgumentException::class) constructor(@Transient vararg val nodes: UInt) : Asn1Encodable<Asn1Primitive> {
 
     init {
         if (nodes.size < 2) throw IllegalArgumentException("at least two nodes required!")
@@ -93,6 +93,7 @@ class ObjectIdentifier(@Transient vararg val nodes: UInt) : Asn1Encodable<Asn1Pr
          * @return ObjectIdentifier if decoding succeeded
          * @throws Throwable all sorts of errors on invalid input
          */
+        @Throws(Throwable::class)
         fun parse(rawValue: ByteArray): ObjectIdentifier {
             if (rawValue.isEmpty()) throw IllegalArgumentException("Empty OIDs are not supported")
             val (first, second) =

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/BitSet.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/BitSet.kt
@@ -42,7 +42,7 @@ private fun Byte.getBit(index: Int): Boolean =
  *
  * Implements [Iterable] over bits. Use [bytes] to iterate over bytes
  */
-@Serializable(with=BitSetSerializer::class)
+@Serializable(with = BitSetSerializer::class)
 class BitSet private constructor(private val buffer: MutableList<Byte>) : Iterable<Boolean> {
 
 
@@ -227,7 +227,9 @@ class BitSet private constructor(private val buffer: MutableList<Byte>) : Iterab
 
         /**
          * Creates bitset from hunan-readably bit string representation
+         * @throws IllegalArgumentException if the provided string containes characters other than '1' and '0'
          */
+        @Throws(IllegalArgumentException::class)
         fun fromBitString(bitString: String): BitSet {
             if (bitString.isEmpty()) return BitSet()
             if (!bitString.matches(Regex("^[01]+\$"))) throw IllegalArgumentException("Not a bit string")
@@ -237,6 +239,11 @@ class BitSet private constructor(private val buffer: MutableList<Byte>) : Iterab
                 }
             }
         }
+
+        /**
+         * Exception-free version of [fromBitString]
+         */
+        fun fromBitStringOrNull(bitString: String) = runCatching { fromBitString(bitString) }.getOrNull()
     }
 }
 
@@ -301,13 +308,13 @@ fun ByteArray.toBitString(): String =
 fun ByteArray.memDump(): String =
     joinToString(separator = " ") { it.toUByte().toString(2).padStart(8, '0') }
 
-object BitSetSerializer:KSerializer<BitSet>{
+object BitSetSerializer : KSerializer<BitSet> {
     override val descriptor = PrimitiveSerialDescriptor("BitSet", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder) = BitSet.fromBitString(decoder.decodeString())
 
     override fun serialize(encoder: Encoder, value: BitSet) {
-       encoder.encodeString(value.toBitString())
+        encoder.encodeString(value.toBitString())
     }
 
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/DistinguishedName.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/DistinguishedName.kt
@@ -81,6 +81,7 @@ sealed class DistinguishedName : Asn1Encodable<Asn1Set>, Identifiable {
     companion object : Asn1Decodable<Asn1Set, DistinguishedName> {
 
         @OptIn(ExperimentalUnsignedTypes::class)
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Set): DistinguishedName {
             if (src.children.size != 1) throw IllegalArgumentException("Invalid Subject Structure")
             val sequence = src.nextChild() as Asn1Sequence

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/DistinguishedName.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/DistinguishedName.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package at.asitplus.crypto.datatypes.pki
 
 import at.asitplus.crypto.datatypes.asn1.*
@@ -81,15 +83,15 @@ sealed class DistinguishedName : Asn1Encodable<Asn1Set>, Identifiable {
     companion object : Asn1Decodable<Asn1Set, DistinguishedName> {
 
         @OptIn(ExperimentalUnsignedTypes::class)
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Set): DistinguishedName {
-            if (src.children.size != 1) throw IllegalArgumentException("Invalid Subject Structure")
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Set): DistinguishedName = runRethrowing {
+            if (src.children.size != 1) throw Asn1StructuralException("Invalid Subject Structure")
             val sequence = src.nextChild() as Asn1Sequence
             val oid = (sequence.nextChild() as Asn1Primitive).readOid()
             if (oid.nodes.size >= 3 && oid.toString().startsWith("2.5.4.")) {
                 val asn1String = sequence.nextChild() as Asn1Primitive
                 val str = runCatching { (asn1String).readString() }
-                if (sequence.hasMoreChildren()) throw IllegalArgumentException("Superfluous elements in RDN")
+                if (sequence.hasMoreChildren()) throw Asn1StructuralException("Superfluous elements in RDN")
                 return when (oid) {
                     CommonName.OID -> str.fold(onSuccess = { CommonName(it) }, onFailure = { CommonName(asn1String) })
                     Country.OID -> str.fold(onSuccess = { Country(it) }, onFailure = { Country(asn1String) })
@@ -105,7 +107,7 @@ sealed class DistinguishedName : Asn1Encodable<Asn1Set>, Identifiable {
                 }
             }
             return Other(oid, sequence.nextChild())
-                .also { if (sequence.hasMoreChildren()) throw IllegalArgumentException("Superfluous elements in RDN") }
+                .also { if (sequence.hasMoreChildren()) throw Asn1StructuralException("Superfluous elements in RDN") }
         }
     }
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
@@ -52,6 +52,7 @@ data class TbsCertificationRequest(
     }
 
     companion object : Asn1Decodable<Asn1Sequence, TbsCertificationRequest> {
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Sequence) = runCatching {
             val version = (src.nextChild() as Asn1Primitive).readInt()
             val subject = (src.nextChild() as Asn1Sequence).children.map {
@@ -115,6 +116,7 @@ data class Pkcs10CertificationRequest(
 
     companion object : Asn1Decodable<Asn1Sequence, Pkcs10CertificationRequest> {
 
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Sequence): Pkcs10CertificationRequest {
             val tbsCsr = TbsCertificationRequest.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val sigAlg = JwsAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
@@ -52,19 +52,19 @@ data class TbsCertificationRequest(
     }
 
     companion object : Asn1Decodable<Asn1Sequence, TbsCertificationRequest> {
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence) = runCatching {
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence) = runRethrowing {
             val version = (src.nextChild() as Asn1Primitive).readInt()
             val subject = (src.nextChild() as Asn1Sequence).children.map {
                 DistinguishedName.decodeFromTlv(it as Asn1Set)
             }
             val cryptoPublicKey = CryptoPublicKey.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val attributes = if (src.hasMoreChildren()) {
-                (src.nextChild() as Asn1Tagged).verify(0u)
+                (src.nextChild() as Asn1Tagged).verifyTag(0u)
                     .map { Pkcs10CertificationRequestAttribute.decodeFromTlv(it as Asn1Sequence) }
             } else null
 
-            if (src.hasMoreChildren()) throw IllegalArgumentException("Superfluous Data in CSR Structure")
+            if (src.hasMoreChildren()) throw Asn1StructuralException("Superfluous Data in CSR Structure")
 
             TbsCertificationRequest(
                 version = version,
@@ -72,7 +72,7 @@ data class TbsCertificationRequest(
                 publicKey = cryptoPublicKey,
                 attributes = attributes,
             )
-        }.getOrElse { throw if (it is IllegalArgumentException) it else IllegalArgumentException(it) }
+        }
     }
 }
 
@@ -88,6 +88,8 @@ data class Pkcs10CertificationRequest(
     val signature: ByteArray
 ) : Asn1Encodable<Asn1Sequence> {
 
+
+    @Throws(Asn1Exception::class)
     override fun encodeToTlv() = asn1Sequence {
         append(tbsCsr)
         append(signatureAlgorithm)
@@ -116,12 +118,12 @@ data class Pkcs10CertificationRequest(
 
     companion object : Asn1Decodable<Asn1Sequence, Pkcs10CertificationRequest> {
 
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence): Pkcs10CertificationRequest {
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence): Pkcs10CertificationRequest = runRethrowing {
             val tbsCsr = TbsCertificationRequest.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val sigAlg = JwsAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val signature = (src.nextChild() as Asn1Primitive).readBitString()
-            if (src.hasMoreChildren()) throw IllegalArgumentException("Superfluous structure in CSR Structure")
+            if (src.hasMoreChildren()) throw Asn1StructuralException("Superfluous structure in CSR Structure")
             return Pkcs10CertificationRequest(tbsCsr, sigAlg, signature.rawBytes)
         }
     }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequestAttribute.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequestAttribute.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package at.asitplus.crypto.datatypes.pki
 
 import at.asitplus.crypto.datatypes.asn1.*
@@ -11,7 +13,7 @@ data class Pkcs10CertificationRequestAttribute(
     constructor(id: ObjectIdentifier, value: Asn1Element) : this(id, listOf(value))
 
     override fun encodeToTlv() = asn1Sequence {
-        append ( oid )
+        append(oid)
         set { value.forEach { append(it) } }
     }
 
@@ -35,8 +37,8 @@ data class Pkcs10CertificationRequestAttribute(
     }
 
     companion object : Asn1Decodable<Asn1Sequence, Pkcs10CertificationRequestAttribute> {
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence): Pkcs10CertificationRequestAttribute {
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence): Pkcs10CertificationRequestAttribute = runRethrowing {
             val id = (src.children[0] as Asn1Primitive).readOid()
             val value = (src.children.last() as Asn1Set).children
             return Pkcs10CertificationRequestAttribute(id, value)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequestAttribute.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequestAttribute.kt
@@ -35,6 +35,7 @@ data class Pkcs10CertificationRequestAttribute(
     }
 
     companion object : Asn1Decodable<Asn1Sequence, Pkcs10CertificationRequestAttribute> {
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Sequence): Pkcs10CertificationRequestAttribute {
             val id = (src.children[0] as Asn1Primitive).readOid()
             val value = (src.children.last() as Asn1Set).children

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
@@ -32,42 +32,45 @@ data class TbsCertificate(
         tagged(0u) { int(value) }
     }
 
-    override fun encodeToTlv() = asn1Sequence {
-        version(version)
-        append(Asn1Primitive(BERTags.INTEGER, serialNumber))
-        append(signatureAlgorithm)
-        sequence { issuerName.forEach { append(it) } }
+    @Throws(Asn1Exception::class)
+    override fun encodeToTlv() = runRethrowing {
+        asn1Sequence {
+            version(version)
+            append(Asn1Primitive(BERTags.INTEGER, serialNumber))
+            append(signatureAlgorithm)
+            sequence { issuerName.forEach { append(it) } }
 
-        sequence {
-            append(validFrom)
-            append(validUntil)
-        }
+            sequence {
+                append(validFrom)
+                append(validUntil)
+            }
 
-        sequence { subjectName.forEach { append(it) } }
+            sequence { subjectName.forEach { append(it) } }
 
-        //subject public key
-        append(publicKey)
+            //subject public key
+            append(publicKey)
 
-        issuerUniqueID?.let {
-            append(
-                Asn1Primitive(
-                    1u.toImplicitTag(),
-                    Asn1BitString(it).let { byteArrayOf(it.numPaddingBits, *it.rawBytes) })
-            )
-        }
-        subjectUniqueID?.let {
-            append(
-                Asn1Primitive(
-                    1u.toImplicitTag(),
-                    Asn1BitString(it).let { byteArrayOf(it.numPaddingBits, *it.rawBytes) })
-            )
-        }
+            issuerUniqueID?.let {
+                append(
+                    Asn1Primitive(
+                        1u.toImplicitTag(),
+                        Asn1BitString(it).let { byteArrayOf(it.numPaddingBits, *it.rawBytes) })
+                )
+            }
+            subjectUniqueID?.let {
+                append(
+                    Asn1Primitive(
+                        1u.toImplicitTag(),
+                        Asn1BitString(it).let { byteArrayOf(it.numPaddingBits, *it.rawBytes) })
+                )
+            }
 
-        extensions?.let {
-            if (it.isNotEmpty()) {
-                tagged(3u) {
-                    sequence {
-                        it.forEach { ext -> append(ext) }
+            extensions?.let {
+                if (it.isNotEmpty()) {
+                    tagged(3u) {
+                        sequence {
+                            it.forEach { ext -> append(ext) }
+                        }
                     }
                 }
             }
@@ -75,11 +78,11 @@ data class TbsCertificate(
     }
 
     companion object : Asn1Decodable<Asn1Sequence, TbsCertificate> {
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence) = runCatching {
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence) = runRethrowing {
             //TODO make sure to always check for superfluous data
             val version = src.nextChild().let {
-                ((it as Asn1Tagged).verify(0u).single() as Asn1Primitive).readInt()
+                ((it as Asn1Tagged).verifyTag(0u).single() as Asn1Primitive).readInt()
             }
             val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
             val sigAlg = JwsAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
@@ -106,12 +109,12 @@ data class TbsCertificate(
                 } else null
             }
             val extensions = if (src.hasMoreChildren()) {
-                ((src.nextChild() as Asn1Tagged).verify(3u).single() as Asn1Sequence).children.map {
+                ((src.nextChild() as Asn1Tagged).verifyTag(3u).single() as Asn1Sequence).children.map {
                     X509CertificateExtension.decodeFromTlv(it as Asn1Sequence)
                 }
             } else null
 
-            if (src.hasMoreChildren()) throw IllegalArgumentException("Superfluous Data in Certificate Structure")
+            if (src.hasMoreChildren()) throw Asn1StructuralException("Superfluous Data in Certificate Structure")
 
             TbsCertificate(
                 version = version,
@@ -126,15 +129,15 @@ data class TbsCertificate(
                 subjectUniqueID = subjectUniqueID?.toBitSet(),
                 extensions = extensions,
             )
-        }.getOrElse { throw if (it is IllegalArgumentException) it else IllegalArgumentException(it) }
+        }
 
         private fun decodeTimestamps(input: Asn1Sequence): Pair<Asn1Time, Asn1Time> =
-            runCatching {
+            runRethrowing {
                 val firstInstant = Asn1Time.decodeFromTlv(input.nextChild() as Asn1Primitive)
                 val secondInstant = Asn1Time.decodeFromTlv(input.nextChild() as Asn1Primitive)
-                if (input.hasMoreChildren()) throw IllegalArgumentException("Superfluous content in Validity")
+                if (input.hasMoreChildren()) throw Asn1StructuralException("Superfluous content in Validity")
                 return Pair(firstInstant, secondInstant)
-            }.getOrElse { throw if (it is IllegalArgumentException) it else IllegalArgumentException(it) }
+            }
     }
 }
 
@@ -149,6 +152,8 @@ data class X509Certificate(
     val signature: ByteArray
 ) : Asn1Encodable<Asn1Sequence> {
 
+
+    @Throws(Asn1Exception::class)
     override fun encodeToTlv() = asn1Sequence {
         append(tbsCertificate)
         append(signatureAlgorithm)
@@ -179,12 +184,12 @@ data class X509Certificate(
 
     companion object : Asn1Decodable<Asn1Sequence, X509Certificate> {
 
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence): X509Certificate {
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence): X509Certificate = runRethrowing {
             val tbs = TbsCertificate.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val sigAlg = JwsAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val signature = (src.nextChild() as Asn1Primitive).readBitString()
-            if (src.hasMoreChildren()) throw IllegalArgumentException("Superfluous structure in Certificate Structure")
+            if (src.hasMoreChildren()) throw Asn1StructuralException("Superfluous structure in Certificate Structure")
             return X509Certificate(tbs, sigAlg, signature.rawBytes)
         }
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
@@ -75,6 +75,7 @@ data class TbsCertificate(
     }
 
     companion object : Asn1Decodable<Asn1Sequence, TbsCertificate> {
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Sequence) = runCatching {
             //TODO make sure to always check for superfluous data
             val version = src.nextChild().let {
@@ -178,6 +179,7 @@ data class X509Certificate(
 
     companion object : Asn1Decodable<Asn1Sequence, X509Certificate> {
 
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Sequence): X509Certificate {
             val tbs = TbsCertificate.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val sigAlg = JwsAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509CertificateExtension.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509CertificateExtension.kt
@@ -37,6 +37,7 @@ data class X509CertificateExtension private constructor(
 
     companion object : Asn1Decodable<Asn1Sequence, X509CertificateExtension> {
 
+        @Throws(Throwable::class)
         override fun decodeFromTlv(src: Asn1Sequence): X509CertificateExtension {
 
             val id = (src.children[0] as Asn1Primitive).readOid()

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509CertificateExtension.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509CertificateExtension.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package at.asitplus.crypto.datatypes.pki
 
 import at.asitplus.crypto.datatypes.asn1.*
@@ -7,14 +9,14 @@ import kotlinx.serialization.Serializable
  * X.509 Certificate Extension
  */
 @Serializable
-data class X509CertificateExtension private constructor(
+data class X509CertificateExtension @Throws(Asn1Exception::class) private constructor(
     override val oid: ObjectIdentifier,
     val value: Asn1Element,
     val critical: Boolean = false
 ) : Asn1Encodable<Asn1Sequence>, Identifiable {
 
     init {
-        if (value.tag != BERTags.OCTET_STRING) throw IllegalArgumentException("Value is not an octet string!")
+        if (value.tag != BERTags.OCTET_STRING) throw Asn1TagMismatchException(BERTags.OCTET_STRING, value.tag)
     }
 
     public constructor(
@@ -37,8 +39,8 @@ data class X509CertificateExtension private constructor(
 
     companion object : Asn1Decodable<Asn1Sequence, X509CertificateExtension> {
 
-        @Throws(Throwable::class)
-        override fun decodeFromTlv(src: Asn1Sequence): X509CertificateExtension {
+        @Throws(Asn1Exception::class)
+        override fun decodeFromTlv(src: Asn1Sequence): X509CertificateExtension = runRethrowing {
 
             val id = (src.children[0] as Asn1Primitive).readOid()
             val critical =

--- a/datatypes/src/jvmTest/kotlin/Pkcs10CertificationRequestJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/Pkcs10CertificationRequestJvmTest.kt
@@ -52,13 +52,13 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
             initSign(keyPair.private)
-            update(tbsCsr.encodeToDER())
+            update(tbsCsr.encodeToDer())
         }.sign()
         val csr = Pkcs10CertificationRequest(tbsCsr, signatureAlgorithm, signed)
 
         println(csr.encodeToTlv().toDerHexString(lineLen = 64))
 
-        val kotlinEncoded = csr.encodeToDER()
+        val kotlinEncoded = csr.encodeToDer()
 
         val contentSigner: ContentSigner = JcaContentSignerBuilder(signatureAlgorithm.jcaName).build(keyPair.private)
         val spki = SubjectPublicKeyInfo.getInstance(keyPair.public.encoded)

--- a/datatypes/src/jvmTest/kotlin/Pkcs10CertificationRequestJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/Pkcs10CertificationRequestJvmTest.kt
@@ -52,13 +52,13 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
             initSign(keyPair.private)
-            update(tbsCsr.derEncoded)
+            update(tbsCsr.encodeToDER())
         }.sign()
         val csr = Pkcs10CertificationRequest(tbsCsr, signatureAlgorithm, signed)
 
         println(csr.encodeToTlv().toDerHexString(lineLen = 64))
 
-        val kotlinEncoded = csr.derEncoded
+        val kotlinEncoded = csr.encodeToDER()
 
         val contentSigner: ContentSigner = JcaContentSignerBuilder(signatureAlgorithm.jcaName).build(keyPair.private)
         val spki = SubjectPublicKeyInfo.getInstance(keyPair.public.encoded)

--- a/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
+++ b/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
@@ -43,12 +43,12 @@ class PublicKeyTest : FreeSpec({
                 own.shouldNotBeNull()
                 println(Json.encodeToString(own))
                 println(own.iosEncoded.encodeToString(Base16()))
-                println(own.derEncoded.encodeToString(Base16()))
+                println(own.encodeToDER().encodeToString(Base16()))
                 println(own.keyId)
-                own.derEncoded shouldBe pubKey.encoded
+                own.encodeToDER() shouldBe pubKey.encoded
                 CryptoPublicKey.fromKeyId(own.keyId) shouldBe own
                 own.getPublicKey().encoded shouldBe pubKey.encoded
-                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.derEncoded) as Asn1Sequence) shouldBe own
+                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDER()) as Asn1Sequence) shouldBe own
             }
         }
 
@@ -96,8 +96,8 @@ class PublicKeyTest : FreeSpec({
                 val keyBytes = ((ASN1InputStream(pubKey.encoded).readObject()
                     .toASN1Primitive() as ASN1Sequence).elementAt(1) as DERBitString).bytes
                 own.iosEncoded shouldBe keyBytes //PKCS#1
-                own.derEncoded shouldBe pubKey.encoded //PKCS#8
-                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.derEncoded) as Asn1Sequence) shouldBe own
+                own.encodeToDER() shouldBe pubKey.encoded //PKCS#8
+                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDER()) as Asn1Sequence) shouldBe own
                 own.getPublicKey().encoded shouldBe pubKey.encoded
             }
         }

--- a/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
+++ b/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
@@ -1,7 +1,6 @@
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.asn1.Asn1Element
 import at.asitplus.crypto.datatypes.asn1.Asn1Sequence
-import at.asitplus.crypto.datatypes.asn1.ensureSize
 import at.asitplus.crypto.datatypes.asn1.parse
 import at.asitplus.crypto.datatypes.fromJcaKey
 import at.asitplus.crypto.datatypes.getPublicKey
@@ -43,12 +42,12 @@ class PublicKeyTest : FreeSpec({
                 own.shouldNotBeNull()
                 println(Json.encodeToString(own))
                 println(own.iosEncoded.encodeToString(Base16()))
-                println(own.encodeToDER().encodeToString(Base16()))
+                println(own.encodeToDer().encodeToString(Base16()))
                 println(own.keyId)
-                own.encodeToDER() shouldBe pubKey.encoded
+                own.encodeToDer() shouldBe pubKey.encoded
                 CryptoPublicKey.fromKeyId(own.keyId) shouldBe own
                 own.getPublicKey().encoded shouldBe pubKey.encoded
-                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDER()) as Asn1Sequence) shouldBe own
+                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDer()) as Asn1Sequence) shouldBe own
             }
         }
 
@@ -96,8 +95,8 @@ class PublicKeyTest : FreeSpec({
                 val keyBytes = ((ASN1InputStream(pubKey.encoded).readObject()
                     .toASN1Primitive() as ASN1Sequence).elementAt(1) as DERBitString).bytes
                 own.iosEncoded shouldBe keyBytes //PKCS#1
-                own.encodeToDER() shouldBe pubKey.encoded //PKCS#8
-                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDER()) as Asn1Sequence) shouldBe own
+                own.encodeToDer() shouldBe pubKey.encoded //PKCS#8
+                CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDer()) as Asn1Sequence) shouldBe own
                 own.getPublicKey().encoded shouldBe pubKey.encoded
             }
         }

--- a/datatypes/src/jvmTest/kotlin/X509CertParserTest.kt
+++ b/datatypes/src/jvmTest/kotlin/X509CertParserTest.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import org.bouncycastle.jcajce.provider.asymmetric.X509
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileReader
@@ -67,7 +66,7 @@ class X509CertParserTest : FreeSpec({
 
             println("The full certificate is:\n${Json { prettyPrint = true }.encodeToString(cert)}")
 
-            println("Re-encoding it produces the same bytes? ${cert.encodeToDER() contentEquals certBytes}")
+            println("Re-encoding it produces the same bytes? ${cert.encodeToDer() contentEquals certBytes}")
 
 
             println(cert.encodeToTlv())

--- a/datatypes/src/jvmTest/kotlin/X509CertParserTest.kt
+++ b/datatypes/src/jvmTest/kotlin/X509CertParserTest.kt
@@ -67,7 +67,7 @@ class X509CertParserTest : FreeSpec({
 
             println("The full certificate is:\n${Json { prettyPrint = true }.encodeToString(cert)}")
 
-            println("Re-encoding it produces the same bytes? ${cert.derEncoded contentEquals certBytes}")
+            println("Re-encoding it produces the same bytes? ${cert.encodeToDER() contentEquals certBytes}")
 
 
             println(cert.encodeToTlv())

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 jvm.version=11
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+kotlin.experimental.tryK2=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,3 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 jvm.version=11
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-kotlin.experimental.tryK2=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,11 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        maven {
+            url = uri("https://raw.githubusercontent.com/a-sit-plus/gradle-conventions-plugin/mvn/repo")
+            name = "aspConventions"
+        }
     }
-    includeBuild("gradle-conventions-plugin")
 }
 include(":datatypes")
 include(":datatypes-jws")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,11 +2,8 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            url = uri("https://raw.githubusercontent.com/a-sit-plus/gradle-conventions-plugin/mvn/repo")
-            name = "aspConventions"
-        }
     }
+    includeBuild("gradle-conventions-plugin")
 }
 include(":datatypes")
 include(":datatypes-jws")


### PR DESCRIPTION
* refactor `.derEncoded` property of `Asn1Encodable` interface to function `.encodeToDer()`
* consistent exception handling behaviour
  * throw new type `Asn1Exception` for ASN.1-related errors
  * add `xxxOrNull()` functions for all encoding/decoding/parsing functions