### PR TITLE
Feature/multi base helper refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,5 @@
   * Return `KmmResult` for conversions between different key representations ( i.e. `CryptoPublicKey`, `CoseKey` and `JsonWebKey`) 
 
 ### NEXT
+* Dependency Updates
+  * KmmResult 1.5.4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 plugins {
-    id("at.asitplus.gradle.conventions") version "1.9.20+20231107" //version can be omitted for composite build
+    id("at.asitplus.gradle.conventions") version "1.9.20+20231114" //version can be omitted for composite build
 }
 group = "at.asitplus.crypto"
 

--- a/buildSrc/src/main/kotlin/DatatypeVersions.kt
+++ b/buildSrc/src/main/kotlin/DatatypeVersions.kt
@@ -1,5 +1,4 @@
 object DatatypeVersions{
     const val encoding= "1.2.3"
-    const val kmmresult="1.5.3"
     const val okio = "3.5.0"
 }

--- a/datatypes-cose/build.gradle.kts
+++ b/datatypes-cose/build.gradle.kts
@@ -1,5 +1,4 @@
 import DatatypeVersions.encoding
-import DatatypeVersions.kmmresult
 import at.asitplus.gradle.*
 
 plugins {
@@ -39,7 +38,7 @@ exportIosFramework(
     "KmpCryptoCose",
     serialization("cbor"),
     datetime(),
-    "at.asitplus:kmmresult:${kmmresult}",
+    kmmresult(),
     project(":datatypes")
 )
 

--- a/datatypes-jws/build.gradle.kts
+++ b/datatypes-jws/build.gradle.kts
@@ -1,5 +1,4 @@
 import DatatypeVersions.encoding
-import DatatypeVersions.kmmresult
 import DatatypeVersions.okio
 import at.asitplus.gradle.*
 
@@ -39,7 +38,7 @@ exportIosFramework(
     "KmpCryptoJws",
     serialization("json"),
     datetime(),
-    "at.asitplus:kmmresult:${kmmresult}",
+    kmmresult(),
     project(":datatypes")
 )
 

--- a/datatypes/build.gradle.kts
+++ b/datatypes/build.gradle.kts
@@ -1,5 +1,4 @@
 import DatatypeVersions.encoding
-import DatatypeVersions.kmmresult
 import at.asitplus.gradle.*
 
 plugins {
@@ -20,7 +19,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api("at.asitplus:kmmresult:${kmmresult}")
+                api(kmmresult())
                 api(serialization("json"))
                 api(datetime())
                 implementation("io.matthewnelson.kotlin-components:encoding-base16:${encoding}")
@@ -42,7 +41,7 @@ kotlin {
         }
     }
 }
-exportIosFramework("KmpCrypto", serialization("json"), datetime(), "at.asitplus:kmmresult:${kmmresult}")
+exportIosFramework("KmpCrypto", serialization("json"), datetime(), kmmresult())
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
@@ -65,9 +65,18 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
          * @throws Throwable all sorts of exception on invalid input
          */
         @Throws(Throwable::class)
-        fun fromKeyId(it: String): CryptoPublicKey =
-            MultibaseHelper.calcPublicKey(it)
-
+        fun fromKeyId(it: String): CryptoPublicKey {
+            val decodedKeyId = MultibaseHelper.decodeKeyId(it)
+            return when (decodedKeyId.first) {
+                true -> Ec.fromAnsiX963Bytes(
+                    byteArrayOf(
+                        Ec.ANSI_PREFIX,
+                        *decodedKeyId.second
+                    )
+                )
+                false -> Rsa.fromPKCS1encoded(decodedKeyId.second)
+            }
+        }
 
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Sequence): CryptoPublicKey = runRethrowing {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/Encoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/Encoding.kt
@@ -98,27 +98,6 @@ object MultibaseHelper {
     private fun multicodecWrapEC(it: ByteArray) = byteArrayOf(0x12.toByte(), 0x90.toByte()) + it
 
     /**
-     * Simple Ec Key encoding, if appended with ANSI_PREFIX then valid ANSI X9.63 encoding
-     * No compression, because decompression would need some EC math
-     */
-    fun encodeEcKey(key: CryptoPublicKey.Ec): ByteArray =
-        key.x.ensureSize(key.curve.coordinateLengthBytes) + key.y.ensureSize(key.curve.coordinateLengthBytes)
-
-    /**
-     * PKCS#1 encoded RSA Public Key
-     */
-    fun encodeRsaKey(key: CryptoPublicKey.Rsa): ByteArray =
-        asn1Sequence {
-            append(
-                Asn1Primitive(
-                    BERTags.INTEGER,
-                    key.n.ensureSize(key.bits.number / 8u)
-                        .let { if (it.first() == 0x00.toByte()) it else byteArrayOf(0x00, *it) })
-            )
-            int(key.e)
-        }.derEncoded
-
-    /**
      * Returns something like `did:key:mEpA...` with the [x] and [y] values appended in Base64.
      * This translates to `Base64(0x12, 0x90, EC-P-{256,384,521}-Key)`.
      * Note that `0x1290` is not an official Multicodec prefix, but there seems to be none for
@@ -127,7 +106,14 @@ object MultibaseHelper {
      */
     fun calcKeyId(key: CryptoPublicKey): String {
         return when (key) {
-            is CryptoPublicKey.Ec -> "$PREFIX_DID_KEY:${multibaseWrapBase64(multicodecWrapEC(encodeEcKey(key)))}"
+            is CryptoPublicKey.Ec -> "$PREFIX_DID_KEY:${
+                multibaseWrapBase64(
+                    multicodecWrapEC(
+                        key.iosEncoded.drop(1).toByteArray()
+                    )
+                )
+            }"
+
             is CryptoPublicKey.Rsa -> "$PREFIX_DID_KEY:${multibaseWrapBase64(multicodecWrapRSA(key.iosEncoded))}"
         }
     }
@@ -136,6 +122,13 @@ object MultibaseHelper {
     private fun multiKeyRemovePrefix(keyId: String): String =
         keyId.takeIf { it.startsWith("$PREFIX_DID_KEY:") }?.removePrefix("$PREFIX_DID_KEY:")
             ?: throw IllegalArgumentException("Key ID does not specify public key")
+
+    @Throws(Throwable::class)
+    private fun multibaseDecode(it: String): ByteArray =
+        if (it.startsWith("m")) {
+            it.removePrefix("m").decodeToByteArrayOrNull(Base64Strict)
+                ?: throw SerializationException("Base64 decoding failed")
+        } else throw IllegalArgumentException("Encoding not supported")
 
     @Throws(Throwable::class)
     private fun multiKeyGetKty(it: ByteArray): Pair<Boolean, ByteArray> =
@@ -150,54 +143,6 @@ object MultibaseHelper {
         }
 
     @Throws(Throwable::class)
-    private fun multibaseDecode(it: String): ByteArray =
-        if (it.startsWith("m")) {
-            it.removePrefix("m").decodeToByteArrayOrNull(Base64Strict)
-                ?: throw SerializationException("Base64 decoding failed")
-        } else throw IllegalArgumentException("Encoding not supported")
-
-    @Throws(Throwable::class)
-    private fun decodeEcKey(it: ByteArray): CryptoPublicKey {
-        val bytes = byteArrayOf(CryptoPublicKey.Ec.ANSI_PREFIX, *it)
-        return CryptoPublicKey.Ec.fromAnsiX963Bytes(bytes)
-    }
-
-    @Throws(Throwable::class)
-    private fun decodeRsaKey(it: ByteArray): CryptoPublicKey =
-        CryptoPublicKey.Rsa.fromPKCS1encoded(it)
-
-    @Throws(Throwable::class)
-    private fun decodeKeyId(keyId: String): Pair<Boolean, ByteArray> =
+    internal fun decodeKeyId(keyId: String): Pair<Boolean, ByteArray> =
         multiKeyGetKty(multibaseDecode(multiKeyRemovePrefix(keyId)))
-
-    @Throws(Throwable::class)
-    internal fun calcPublicKey(keyId: String): CryptoPublicKey {
-        val multiKey = decodeKeyId(keyId)
-        return when (multiKey.first) {
-            true -> decodeEcKey(multiKey.second)
-            false -> decodeRsaKey(multiKey.second)
-        }
-    }
-
-    //These two functions will remain until the latest version of this lib is integrated back into che VC lib.
-    @Deprecated("Use [CryptoPublicKey.fromKeyId] instead")
-    fun calcEcPublicKeyCoords(keyId: String): Pair<ByteArray, ByteArray>? {
-        if (!keyId.startsWith("$PREFIX_DID_KEY:")) return null
-        val stripped = keyId.removePrefix("$PREFIX_DID_KEY:")
-        val multibaseDecode = multibaseDecode(stripped)
-        val multiKey = multiKeyGetKty(multibaseDecode)
-
-        return decodeEcKeyDep(multiKey.second)
-    }
-
-
-    @Deprecated("Use [Ec.fromAnsiX963Bytes] instead")
-    // No decompression, because that would need some EC math
-    private fun decodeEcKeyDep(it: ByteArray?): Pair<ByteArray, ByteArray>? {
-        if (it == null) return null
-        val half: Int = it.size.floorDiv(2)
-        val x = it.sliceArray(0 until half)
-        val y = it.sliceArray(half until it.size)
-        return Pair(x, y)
-    }
 }


### PR DESCRIPTION
Refactor for more precise seperation of responsibility.

MultiBaseHelper now only encodes and decodes KID, the transformation from KID to CryptoPublicKey is now part of the CryptoPublicKey-class - like other transformation CryptoPublicKey.fromXYZ() functions.
This also extends to the iosEncoded value