### PR TITLE
Feature/jws refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,5 @@
   * Return `KmmResult` for conversions between different key representations ( i.e. `CryptoPublicKey`, `CoseKey` and `JsonWebKey`) 
 
 ### NEXT
+* Dependency Updates
+  * KmmResult 1.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,7 @@
 ### NEXT
 * Dependency Updates
   * KmmResult 1.5.4
+* Refactor `MultiBaseHelper` to only handle conversion
+* Change `JwsHeader.publicKey` from JsonWebKey to CryptoPublicKey
+* Remove `SignatureValueLength` parameters from JWS- & Cose Algorithm Enum class
+* Remove deprecated functions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 plugins {
-    id("at.asitplus.gradle.conventions") version "1.9.20+20231107" //version can be omitted for composite build
+    id("at.asitplus.gradle.conventions") version "1.9.20+20231114" //version can be omitted for composite build
 }
 group = "at.asitplus.crypto"
 

--- a/buildSrc/src/main/kotlin/DatatypeVersions.kt
+++ b/buildSrc/src/main/kotlin/DatatypeVersions.kt
@@ -1,5 +1,4 @@
 object DatatypeVersions{
     const val encoding= "1.2.3"
-    const val kmmresult="1.5.3"
     const val okio = "3.5.0"
 }

--- a/datatypes-cose/build.gradle.kts
+++ b/datatypes-cose/build.gradle.kts
@@ -1,5 +1,4 @@
 import DatatypeVersions.encoding
-import DatatypeVersions.kmmresult
 import at.asitplus.gradle.*
 
 plugins {
@@ -39,7 +38,7 @@ exportIosFramework(
     "KmpCryptoCose",
     serialization("cbor"),
     datetime(),
-    "at.asitplus:kmmresult:${kmmresult}",
+    kmmresult(),
     project(":datatypes")
 )
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseAlgorithm.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseAlgorithm.kt
@@ -49,17 +49,6 @@ enum class CoseAlgorithm(val value: Int) {
         RS384 -> JwsAlgorithm.RS384
         RS512 -> JwsAlgorithm.RS512
     }
-
-    val signatureValueLength
-        get() = when (this) {
-            ES256 -> 256 / 8 * 2
-            ES384 -> 384 / 8 * 2
-            ES512 -> 512 / 8 * 2
-            HS256 -> 256 / 8
-            HS384 -> 384 / 8
-            HS512 -> 512 / 8
-            else -> -1 // RSA signatures do not have a fixed size
-        }
 }
 
 
@@ -74,7 +63,7 @@ object CoseAlgorithmSerializer : KSerializer<CoseAlgorithm> {
 
     override fun deserialize(decoder: Decoder): CoseAlgorithm {
         val decoded = decoder.decodeInt()
-        return CoseAlgorithm.values().first { it.value == decoded }
+        return CoseAlgorithm.entries.first { it.value == decoded }
     }
 
 }

--- a/datatypes-jws/build.gradle.kts
+++ b/datatypes-jws/build.gradle.kts
@@ -1,5 +1,4 @@
 import DatatypeVersions.encoding
-import DatatypeVersions.kmmresult
 import DatatypeVersions.okio
 import at.asitplus.gradle.*
 
@@ -39,7 +38,7 @@ exportIosFramework(
     "KmpCryptoJws",
     serialization("json"),
     datetime(),
-    "at.asitplus:kmmresult:${kmmresult}",
+    kmmresult(),
     project(":datatypes")
 )
 

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
@@ -2,6 +2,7 @@
 
 package at.asitplus.crypto.datatypes.jws
 
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import io.github.aakira.napier.Napier
@@ -71,11 +72,8 @@ data class JsonWebToken(
     }
 
     companion object {
-        fun deserialize(it: String) = kotlin.runCatching {
+        fun deserialize(it: String) = runCatching {
             jsonSerializer.decodeFromString<JsonWebToken>(it)
-        }.getOrElse {
-            Napier.w("deserialize failed", it)
-            null
-        }
+        }.wrap()
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwkType.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwkType.kt
@@ -16,7 +16,8 @@ import kotlinx.serialization.encoding.Encoder
 @Serializable(with = JwkTypeSerializer::class)
 enum class JwkType(val text: String) {
     EC("EC"),
-    RSA("RSA");
+    RSA("RSA"),
+    SYM("oct");
 }
 
 object JwkTypeSerializer : KSerializer<JwkType?> {
@@ -30,6 +31,6 @@ object JwkTypeSerializer : KSerializer<JwkType?> {
 
     override fun deserialize(decoder: Decoder): JwkType? {
         val decoded = decoder.decodeString()
-        return JwkType.values().firstOrNull { it.text == decoded }
+        return JwkType.entries.firstOrNull { it.text == decoded }
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsExtensions.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsExtensions.kt
@@ -17,7 +17,7 @@ object JwsExtensions {
      * if it is wrapped in an ASN.1 Sequence of two ASN.1 Integers
      * (e.g. when computed in Java)
      */
-    fun ByteArray.extractSignatureValues(expectedLength: Int): ByteArray {
+    fun ByteArray.extractSignatureValues(expectedLength: UInt): ByteArray {
         if (this[0] != ASN1_TAG_SEQUENCE) return this
         val sequenceLen = this[1]
         if (size != (2 + sequenceLen)) return this
@@ -35,8 +35,8 @@ object JwsExtensions {
         val sEndIndex = sStartIndex + sLength
         val rValue = sliceArray(rStartIndex until rEndIndex)
         val sValue = sliceArray(sStartIndex until sEndIndex)
-        val rValueRaw = rValue.stripLeadingSignByte().padWithZeros(expectedLength)
-        val sValueRaw = sValue.stripLeadingSignByte().padWithZeros(expectedLength)
+        val rValueRaw = rValue.stripLeadingSignByte().padWithZeros(expectedLength.toInt())
+        val sValueRaw = sValue.stripLeadingSignByte().padWithZeros(expectedLength.toInt())
         return rValueRaw + sValueRaw
     }
 

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -51,7 +51,7 @@ data class JwsSigned(
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
             val payload = stringList[1].decodeToByteArrayOrNull(Base64Strict)
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
-            val signature = stringList[2].decodeToByteArrayOrNull(Base64Strict) //TODO() RSA and OCT?
+            val signature = stringList[2].decodeToByteArrayOrNull(Base64Strict)
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
             return JwsSigned(header, payload, signature, "${stringList[0]}.${stringList[1]}")
         }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -51,7 +51,7 @@ data class JwsSigned(
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
             val payload = stringList[1].decodeToByteArrayOrNull(Base64Strict)
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
-            val signature = stringList[2].decodeToByteArrayOrNull(Base64Strict)
+            val signature = stringList[2].decodeToByteArrayOrNull(Base64Strict) //TODO() RSA and OCT?
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
             return JwsSigned(header, payload, signature, "${stringList[0]}.${stringList[1]}")
         }

--- a/datatypes/build.gradle.kts
+++ b/datatypes/build.gradle.kts
@@ -1,5 +1,4 @@
 import DatatypeVersions.encoding
-import DatatypeVersions.kmmresult
 import at.asitplus.gradle.*
 
 plugins {
@@ -20,7 +19,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api("at.asitplus:kmmresult:${kmmresult}")
+                api(kmmresult())
                 api(serialization("json"))
                 api(datetime())
                 implementation("io.matthewnelson.kotlin-components:encoding-base16:${encoding}")
@@ -42,7 +41,7 @@ kotlin {
         }
     }
 }
-exportIosFramework("KmpCrypto", serialization("json"), datetime(), "at.asitplus:kmmresult:${kmmresult}")
+exportIosFramework("KmpCrypto", serialization("json"), datetime(), kmmresult())
 
 val javadocJar = setupDokka(baseUrl = "https://github.com/a-sit-plus/kmp-crypto/tree/main/", multiModuleDoc = true)
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/EcCurve.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/EcCurve.kt
@@ -21,7 +21,7 @@ enum class EcCurve(
     val jwkName: String,
     val keyLengthBits: UInt,
     val coordinateLengthBytes: UInt = keyLengthBits / 8u,
-    val signatureLengthBytes: UInt = coordinateLengthBytes,
+    val signatureLengthBytes: UInt = coordinateLengthBytes * 2u,
     override val oid: ObjectIdentifier
 ) : Identifiable {
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/JwsAlgorithm.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/JwsAlgorithm.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalUnsignedTypes::class)
-
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.*
@@ -40,23 +38,6 @@ enum class JwsAlgorithm(val identifier: String, override val oid: ObjectIdentifi
      * The one exception, which is not a valid JWS algorithm identifier
      */
     NON_JWS_SHA1_WITH_RSA("RS1", KnownOIDs.sha1WithRSAEncryption);
-
-    /**
-     * For `ESXXX` and `HSXXX` this is the length (in bytes) of the signature value obtained when using a certain signature algorithm.
-     *
-     * `null` for RSA-based signatures with length depending on the key size (i.e. `PSXXX`, `RSXXX`, and [NON_JWS_SHA1_WITH_RSA])
-     *
-     */
-    val signatureValueLength: Int?
-        get() = when (this) {
-            ES256 -> 256 / 8 * 2
-            ES384 -> 384 / 8 * 2
-            ES512 -> 512 / 8 * 2
-            HS256 -> 256 / 8
-            HS384 -> 384 / 8
-            HS512 -> 512 / 8
-            else -> null
-        }
 
     private fun encodePSSParams(bits: Int): Asn1Sequence {
         val shaOid = when (bits) {

--- a/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
+++ b/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
@@ -74,7 +74,6 @@ fun CryptoPublicKey.Rsa.getPublicKey(): RSAPublicKey =
         RSAPublicKeySpec(BigInteger(1, n), BigInteger.valueOf(e.toLong()))
     ) as RSAPublicKey
 
-@Throws(Throwable::class)
 fun CryptoPublicKey.Ec.Companion.fromJcaKey(publicKey: ECPublicKey): KmmResult<CryptoPublicKey> =
     runCatching {
         val curve = EcCurve.byJcaName(
@@ -94,7 +93,6 @@ fun CryptoPublicKey.Ec.Companion.fromJcaKey(publicKey: ECPublicKey): KmmResult<C
 fun CryptoPublicKey.Rsa.Companion.fromJcaKey(publicKey: RSAPublicKey): KmmResult<CryptoPublicKey> =
     runCatching { CryptoPublicKey.Rsa(publicKey.modulus.toByteArray(), publicKey.publicExponent.toInt()) }.wrap()
 
-@Throws(Throwable::class)
 fun CryptoPublicKey.Companion.fromJcaKey(publicKey: PublicKey): KmmResult<CryptoPublicKey> =
         when (publicKey) {
             is RSAPublicKey -> CryptoPublicKey.Rsa.fromJcaKey(publicKey)


### PR DESCRIPTION
Refactor JWS services to use more of our new features + small clean ups.
SignatureValueLengths are now handled over the Ec.Curve.signatureLengthBytes variable instead.