### PR TITLE
Fix JWS parsing

### DIFF
--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -14,12 +14,9 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 data class JwsSigned(
     val header: JwsHeader,
     val payload: ByteArray,
-    val signature: CryptoSignature
+    val signature: CryptoSignature,
+    val plainSignatureInput: String,
 ) {
-
-    val plainSignatureInput: String by lazy {
-        prepareJwsSignatureInput(header, payload)
-    }
 
     fun serialize(): String {
         return "${plainSignatureInput}.${signature.rawByteArray.encodeToString(Base64UrlStrict)}"
@@ -61,10 +58,8 @@ data class JwsSigned(
                     }
                 } ?: return null.also { Napier.w("Could not parse JWS: $it") }
 
-            return JwsSigned(header, payload, signature)
+            return JwsSigned(header, payload, signature, stringList[0] + "." + stringList[1])
         }
     }
 }
 
-fun prepareJwsSignatureInput(header: JwsHeader, payload: ByteArray): String =
-    "${header.serialize().encodeToByteArray().encodeToString(Base64UrlStrict)}.${payload.encodeToString(Base64UrlStrict)}"

--- a/datatypes-jws/src/jvmTest/kotlin/JwsSignedTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/JwsSignedTest.kt
@@ -1,0 +1,38 @@
+import at.asitplus.crypto.datatypes.CryptoPublicKey
+import at.asitplus.crypto.datatypes.getJcaPublicKey
+import at.asitplus.crypto.datatypes.jws.JwsSigned
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.security.Signature
+
+class JwsSignedTest : FreeSpec({
+
+    "JWS can be parsed and verified" - {
+        val input = """
+            eyJhbGciOiJFUzI1NiIsImtpZCI6ImRpZDprZXk6bUVwQzNtYjJEaDZLY2FiOE1UWVJrQi9kRnlRbUk4VTZMVUs0L1gzZXlSalFmRG1ZdDJJ
+            aDB1VWpZMno5enIvYjNoT1IvTDhwa0JGZXRqNUUyYTJHQXlyREEiLCJ0eXAiOiJrYitqd3QifQ.eyJpYXQiOjE3MDI1NjE2OTAsImF1ZCI6I
+            mRpZDprZXk6bUVwQzhtWWR1ajcrc3BKd2dUY01TeUw1ZkFxcTFtOS92OGFnd1VuQzZIVTFDKzIra2FUdFRLelN6bXVjb3RtWTdiTWFtSGEvb
+            m90cjlPMDB3Wi8rR0tpeDAiLCJub25jZSI6Ijc1N2M2NmQwLTMwN2MtNDhjZC1iZGRiLTU3MmIyMWQxNzYxNiJ9.Xf-5dG7Bk5A4VnigYdA5
+            NKpH2D9EzAhfckXCKleKHsTDyudswCU3pTaw2jYxafPX68X6QMnvlk14evw_kI8O9Q
+        """.trimIndent()
+
+        val parsed = JwsSigned.parse(input)
+        parsed.shouldNotBeNull()
+
+        val publicKey = parsed.header.publicKey
+        publicKey.shouldNotBeNull()
+        publicKey.shouldBeInstanceOf<CryptoPublicKey.Ec>()
+        val jcaKey = publicKey.getJcaPublicKey().getOrThrow()
+        val asn1Signature = parsed.signature.encodeToDer()
+        val signatureInput = parsed.plainSignatureInput.encodeToByteArray()
+
+        val result = Signature.getInstance("SHA256withECDSA").apply {
+            initVerify(jcaKey)
+            update(signatureInput)
+        }.verify(asn1Signature)
+        result.shouldBeTrue()
+    }
+
+})


### PR DESCRIPTION
Always take the unmodified serialization as input for signature
verification, there is no canoicalization in JWS