### PR TITLE
Change return type of toJsonWebKey

### DIFF
--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -1,7 +1,6 @@
 package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.KmmResult
-import at.asitplus.KmmResult.Companion.success
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.EcCurve
@@ -45,7 +44,7 @@ data class JsonWebKey(
     //Symmetric Key
     @SerialName("k")
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
-    val k: ByteArray? = null
+    val k: ByteArray? = null,
 ) {
 
     val jwkThumbprint: String by lazy {
@@ -150,40 +149,37 @@ data class JsonWebKey(
             runCatching { jsonSerializer.decodeFromString<JsonWebKey>(it) }.wrap()
 
         fun fromKeyId(it: String): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.fromKeyId(it).toJsonWebKey().getOrThrow() }.wrap()
+            runCatching { CryptoPublicKey.fromKeyId(it).toJsonWebKey() }.wrap()
 
         fun fromIosEncoded(bytes: ByteArray): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.fromIosEncoded(bytes).toJsonWebKey().getOrThrow() }.wrap()
+            runCatching { CryptoPublicKey.fromIosEncoded(bytes).toJsonWebKey() }.wrap()
 
         fun fromCoordinates(curve: EcCurve, x: ByteArray, y: ByteArray): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.Ec.fromCoordinates(curve, x, y).toJsonWebKey().getOrThrow() }.wrap()
+            runCatching { CryptoPublicKey.Ec.fromCoordinates(curve, x, y).toJsonWebKey() }.wrap()
     }
 }
 
 /**
- * Converts a [CryptoPublicKey] to a KmmResult wrapped [JsonWebKey] - will never fail, wrapping for consistent types
+ * Converts a [CryptoPublicKey] to a [JsonWebKey]
  */
-fun CryptoPublicKey.toJsonWebKey(): KmmResult<JsonWebKey> =
+fun CryptoPublicKey.toJsonWebKey(): JsonWebKey =
     when (this) {
         is CryptoPublicKey.Ec ->
-            success(
-                JsonWebKey(
-                    type = JwkType.EC,
-                    keyId = jwkId,
-                    curve = curve,
-                    x = x,
-                    y = y
-                )
+            JsonWebKey(
+                type = JwkType.EC,
+                keyId = jwkId,
+                curve = curve,
+                x = x,
+                y = y
             )
 
+
         is CryptoPublicKey.Rsa ->
-            success(
-                JsonWebKey(
-                    type = JwkType.RSA,
-                    keyId = jwkId,
-                    n = n,
-                    e = e.encodeToByteArray()
-                )
+            JsonWebKey(
+                type = JwkType.RSA,
+                keyId = jwkId,
+                n = n,
+                e = e.encodeToByteArray()
             )
     }
 

--- a/datatypes-jws/src/jvmTest/kotlin/JsonWebKeyJvmTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/JsonWebKeyJvmTest.kt
@@ -29,7 +29,7 @@ class JsonWebKeyJvmTest : FreeSpec({
         val xFromBc = (keyPair.public as ECPublicKey).w.affineX.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
         val yFromBc = (keyPair.public as ECPublicKey).w.affineY.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
         val pubKey = CryptoPublicKey.Ec.fromCoordinates(ecCurve, xFromBc, yFromBc)
-        val jsonWebKey = pubKey.toJsonWebKey().getOrThrow()
+        val jsonWebKey = pubKey.toJsonWebKey()
 
         jsonWebKey.shouldNotBeNull()
         jsonWebKey.x shouldBe xFromBc
@@ -55,7 +55,7 @@ class JsonWebKeyJvmTest : FreeSpec({
         val nFromBc = (keyPairRSA.public as RSAPublicKey).modulus.toByteArray()
         val eFromBc = (keyPairRSA.public as RSAPublicKey).publicExponent.toInt()
         val pubKey = CryptoPublicKey.Rsa(nFromBc, eFromBc)
-        val jwk = pubKey.toJsonWebKey().getOrThrow()
+        val jwk = pubKey.toJsonWebKey()
 
         jwk.shouldNotBeNull()
         jwk.n shouldBe nFromBc

--- a/datatypes-jws/src/jvmTest/kotlin/JwkTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/JwkTest.kt
@@ -31,7 +31,7 @@ class JwkTest : FreeSpec({
             ) { pubKey ->
 
                 val cryptoPubKey = CryptoPublicKey.Ec.fromJcaPublicKey(pubKey).getOrThrow()
-                val own = cryptoPubKey.toJsonWebKey().getOrThrow()
+                val own = cryptoPubKey.toJsonWebKey()
                 own.keyId shouldBe cryptoPubKey.jwkId
                 own.shouldNotBeNull()
                 println(own.serialize())


### PR DESCRIPTION
Changed return type of `CryptoPublicKey.toJsonWebKey()` from KmmResult[JsonWebKey] to simply JsonWebKey.
As noted before this conversion cannot fail, and although consistent return types are nice, this really negatively affects code readability down stream.