### PR TITLE
Change keyID to didEncoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,8 @@
   * New `CryptoSignature` class for easy Asn1 - RawByteArray conversion
 * Rename function in file `JcaExtensions.kt` from `.toPublicKey` to `.toJcaPublicKey` to reflect connection to JVMname function in file `JcaExtensions.kt` from `.toPublicKey` to `.toJcaPublicKey` to reflect connection to JVM
 * Remove VcLib-specific constants
+
+### Future Release
+* Change `CryptoPublicKey.toJsonWebKey()` return type from `KmmResult<JsonWebKey>` to `JsonWebKey`
+* Add `CryptoSignature.parseFromJca` function
+* Refactor `CryptoPublicKey.keyID` to `CryptoPublicKey.multiBaseEncoded` to reduce ambiguity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,4 +53,5 @@
 ### Future Release
 * Change `CryptoPublicKey.toJsonWebKey()` return type from `KmmResult<JsonWebKey>` to `JsonWebKey`
 * Add `CryptoSignature.parseFromJca` function
-* Refactor `CryptoPublicKey.keyID` to `CryptoPublicKey.multiBaseEncoded` to reduce ambiguity
+* Refactor `CryptoPublicKey.keyID` to `CryptoPublicKey.didEncoded` to better reflect what it actually is
+* Rename `CryptoPublicKey.fromKeyId` to `CryptoPublicKey.fromDid`

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
@@ -143,7 +143,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null): KmmResult<CoseK
                         y = y
                     ),
                     type = CoseKeyType.EC2,
-                    keyId = keyId.encodeToByteArray(),
+                    keyId = multiBaseEncoded.encodeToByteArray(),
                     algorithm = algorithm
                 )
             )
@@ -161,7 +161,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null): KmmResult<CoseK
                         e = e.encodeToByteArray()
                     ),
                     type = CoseKeyType.RSA,
-                    keyId = keyId.encodeToByteArray(),
+                    keyId = multiBaseEncoded.encodeToByteArray(),
                     algorithm = algorithm
                 )
             )
@@ -169,7 +169,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null): KmmResult<CoseK
 
 private const val COSE_KID = "coseKid"
 var CryptoPublicKey.coseKid: String
-    get() = additionalProperties[COSE_KID] ?: keyId
+    get() = additionalProperties[COSE_KID] ?: multiBaseEncoded
     set(value) {
         additionalProperties[COSE_KID] = value
     }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
@@ -94,7 +94,7 @@ data class CoseKey(
             runCatching { cborSerializer.decodeFromByteArray<CoseKey>(it) }.wrap()
 
         fun fromKeyId(keyId: String): KmmResult<CoseKey> =
-            runCatching { CryptoPublicKey.fromKeyId(keyId).toCoseKey().getOrThrow() }.wrap()
+            runCatching { CryptoPublicKey.fromDid(keyId).toCoseKey().getOrThrow() }.wrap()
 
         fun fromIosEncoded(bytes: ByteArray): KmmResult<CoseKey> =
             runCatching { CryptoPublicKey.fromIosEncoded(bytes).toCoseKey().getOrThrow() }.wrap()
@@ -143,7 +143,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null): KmmResult<CoseK
                         y = y
                     ),
                     type = CoseKeyType.EC2,
-                    keyId = multiBaseEncoded.encodeToByteArray(),
+                    keyId = didEncoded.encodeToByteArray(),
                     algorithm = algorithm
                 )
             )
@@ -161,7 +161,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null): KmmResult<CoseK
                         e = e.encodeToByteArray()
                     ),
                     type = CoseKeyType.RSA,
-                    keyId = multiBaseEncoded.encodeToByteArray(),
+                    keyId = didEncoded.encodeToByteArray(),
                     algorithm = algorithm
                 )
             )
@@ -169,7 +169,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null): KmmResult<CoseK
 
 private const val COSE_KID = "coseKid"
 var CryptoPublicKey.coseKid: String
-    get() = additionalProperties[COSE_KID] ?: multiBaseEncoded
+    get() = additionalProperties[COSE_KID] ?: didEncoded
     set(value) {
         additionalProperties[COSE_KID] = value
     }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -189,7 +189,7 @@ private const val JWK_ID = "jwkIdentifier"
  * Holds [JsonWebKey.keyId] when transforming a [JsonWebKey] to a [CryptoPublicKey]
  */
 var CryptoPublicKey.jwkId: String
-    get() = additionalProperties[JWK_ID] ?: keyId
+    get() = additionalProperties[JWK_ID] ?: multiBaseEncoded
     set(value) {
         additionalProperties[JWK_ID] = value
     }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -149,7 +149,7 @@ data class JsonWebKey(
             runCatching { jsonSerializer.decodeFromString<JsonWebKey>(it) }.wrap()
 
         fun fromKeyId(it: String): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.fromKeyId(it).toJsonWebKey() }.wrap()
+            runCatching { CryptoPublicKey.fromDid(it).toJsonWebKey() }.wrap()
 
         fun fromIosEncoded(bytes: ByteArray): KmmResult<JsonWebKey> =
             runCatching { CryptoPublicKey.fromIosEncoded(bytes).toJsonWebKey() }.wrap()
@@ -189,7 +189,7 @@ private const val JWK_ID = "jwkIdentifier"
  * Holds [JsonWebKey.keyId] when transforming a [JsonWebKey] to a [CryptoPublicKey]
  */
 var CryptoPublicKey.jwkId: String
-    get() = additionalProperties[JWK_ID] ?: multiBaseEncoded
+    get() = additionalProperties[JWK_ID] ?: didEncoded
     set(value) {
         additionalProperties[JWK_ID] = value
     }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsHeader.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsHeader.kt
@@ -2,7 +2,6 @@
 
 package at.asitplus.crypto.datatypes.jws
 
-import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import at.asitplus.crypto.datatypes.asn1.Asn1Element
@@ -88,7 +87,7 @@ data class JwsHeader(
      */
     val publicKey: CryptoPublicKey? by lazy {
         jsonWebKey?.toCryptoPublicKey()?.getOrNull()
-            ?: keyId?.let { runCatching { CryptoPublicKey.fromKeyId(it) } }?.getOrNull()
+            ?: keyId?.let { runCatching { CryptoPublicKey.fromDid(it) } }?.getOrNull()
             ?: certificateChain
                 ?.firstNotNullOfOrNull {
                     runCatching { X509Certificate.decodeFromTlv(Asn1Element.parse(it) as Asn1Sequence).publicKey }.getOrNull()

--- a/datatypes-jws/src/jvmTest/kotlin/JwkTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/JwkTest.kt
@@ -36,7 +36,7 @@ class JwkTest : FreeSpec({
                 own.shouldNotBeNull()
                 println(own.serialize())
                 own.toCryptoPublicKey().getOrThrow().iosEncoded shouldBe cryptoPubKey.iosEncoded
-                CryptoPublicKey.fromKeyId(own.keyId!!) shouldBe cryptoPubKey
+                CryptoPublicKey.fromDid(own.keyId!!) shouldBe cryptoPubKey
             }
         }
     }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
@@ -28,7 +28,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
      * Multibase KID
      */
     @Transient
-    abstract val keyId: String
+    abstract val multiBaseEncoded: String
 
     /**
      * Representation of this key in the same ways as iOS would encode it natively
@@ -195,7 +195,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
         }
 
         @Transient
-        override val keyId by lazy { MultibaseHelper.calcKeyId(this) }
+        override val multiBaseEncoded by lazy { MultibaseHelper.calcKeyId(this) }
 
         /**
          * PKCS#1 encoded RSA Public Key
@@ -276,7 +276,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
         }
 
         @Transient
-        override val keyId by lazy { MultibaseHelper.calcKeyId(this) }
+        override val multiBaseEncoded by lazy { MultibaseHelper.calcKeyId(this) }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
+++ b/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
@@ -130,7 +130,7 @@ val CryptoSignature.jcaSignatureBytes: ByteArray
 /**
  * In Java EC signatures are returned as DER-encoded, RSA signatures however are raw bytearrays
  */
-fun CryptoSignature.parseFromJca(input: ByteArray, algorithm: CryptoAlgorithm)=
+fun CryptoSignature.Companion.parseFromJca(input: ByteArray, algorithm: CryptoAlgorithm)=
     if (algorithm.isEc)
         CryptoSignature.decodeFromDer(input)
     else

--- a/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
+++ b/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
@@ -41,9 +41,9 @@ class PublicKeyTest : FreeSpec({
                 println(Json.encodeToString(own))
                 println(own.iosEncoded.encodeToString(Base16()))
                 println(own.encodeToDer().encodeToString(Base16()))
-                println(own.keyId)
+                println(own.multiBaseEncoded)
                 own.encodeToDer() shouldBe pubKey.encoded
-                CryptoPublicKey.fromKeyId(own.keyId) shouldBe own
+                CryptoPublicKey.fromKeyId(own.multiBaseEncoded) shouldBe own
                 own.getJcaPublicKey().getOrThrow().encoded shouldBe pubKey.encoded
                 CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDer()) as Asn1Sequence) shouldBe own
             }
@@ -89,7 +89,7 @@ class PublicKeyTest : FreeSpec({
 
                 println(Json.encodeToString(own))
                 println(own.iosEncoded.encodeToString(Base16()))
-                println(own.keyId)
+                println(own.multiBaseEncoded)
                 val keyBytes = ((ASN1InputStream(pubKey.encoded).readObject()
                     .toASN1Primitive() as ASN1Sequence).elementAt(1) as DERBitString).bytes
                 own.iosEncoded shouldBe keyBytes //PKCS#1

--- a/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
+++ b/datatypes/src/jvmTest/kotlin/PublicKeyTest.kt
@@ -41,9 +41,9 @@ class PublicKeyTest : FreeSpec({
                 println(Json.encodeToString(own))
                 println(own.iosEncoded.encodeToString(Base16()))
                 println(own.encodeToDer().encodeToString(Base16()))
-                println(own.multiBaseEncoded)
+                println(own.didEncoded)
                 own.encodeToDer() shouldBe pubKey.encoded
-                CryptoPublicKey.fromKeyId(own.multiBaseEncoded) shouldBe own
+                CryptoPublicKey.fromDid(own.didEncoded) shouldBe own
                 own.getJcaPublicKey().getOrThrow().encoded shouldBe pubKey.encoded
                 CryptoPublicKey.decodeFromTlv(Asn1Element.parse(own.encodeToDer()) as Asn1Sequence) shouldBe own
             }
@@ -89,7 +89,7 @@ class PublicKeyTest : FreeSpec({
 
                 println(Json.encodeToString(own))
                 println(own.iosEncoded.encodeToString(Base16()))
-                println(own.multiBaseEncoded)
+                println(own.didEncoded)
                 val keyBytes = ((ASN1InputStream(pubKey.encoded).readObject()
                     .toASN1Primitive() as ASN1Sequence).elementAt(1) as DERBitString).bytes
                 own.iosEncoded shouldBe keyBytes //PKCS#1


### PR DESCRIPTION
Name change to reflect that this 'keyID" is actually just an encoded version of the public key, versus the form-free parameter which is used in JWK.
In the case a JWK KeyID is set at the time of conversion it is still accessible under the aptly named `CryptoPublicKey.jwkId` parameter.