### PR TITLE
Add CBOR Web Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,3 +82,4 @@
  * Implement JWK Set Url (`jku`) in JWS headers
  * Implement Attestation JWT (`jwt`) in JWS headers
  * Implement Confirmation keys (`cnf`) in JWT
+ * Implement `CborWebToken` (RFC 8392)

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CborWebToken.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CborWebToken.kt
@@ -1,0 +1,108 @@
+package at.asitplus.crypto.datatypes.cose
+
+import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.crypto.datatypes.cose.io.Base16Strict
+import at.asitplus.crypto.datatypes.cose.io.cborSerializer
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.datetime.Instant
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
+import kotlinx.serialization.cbor.CborLabel
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
+
+/**
+ * RFC 8392: CBOR Web Token (CWT)
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class CborWebToken(
+    @CborLabel(1)
+    @SerialName("iss")
+    val issuer: String? = null,
+    @CborLabel(2)
+    @SerialName("sub")
+    val subject: String? = null,
+    @CborLabel(3)
+    @SerialName("aud")
+    val audience: String? = null,
+    @CborLabel(4)
+    @SerialName("exp")
+    @Serializable(with = InstantLongSerializer::class)
+    val expiration: Instant? = null,
+    @CborLabel(5)
+    @SerialName("nbf")
+    @Serializable(with = InstantLongSerializer::class)
+    val notBefore: Instant? = null,
+    @CborLabel(6)
+    @SerialName("iat")
+    @Serializable(with = InstantLongSerializer::class)
+    val issuedAt: Instant? = null,
+    @CborLabel(7)
+    @SerialName("jti")
+    @ByteString
+    val cwtId: ByteArray? = null,
+    @CborLabel(10)
+    @SerialName("Nonce")
+    @ByteString
+    val nonce: ByteArray? = null,
+) {
+
+    fun serialize() = cborSerializer.encodeToByteArray(this)
+
+    override fun toString(): String {
+        return "CborWebToken(issuer=$issuer," +
+                " subject=$subject," +
+                " audience=$audience," +
+                " expiration=$expiration," +
+                " notBefore=$notBefore," +
+                " issuedAt=$issuedAt," +
+                " cwtId=${cwtId?.encodeToString(Base16Strict)}," +
+                " nonce=${nonce?.encodeToString(Base16Strict)}" +
+                ")"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as CborWebToken
+
+        if (issuer != other.issuer) return false
+        if (subject != other.subject) return false
+        if (audience != other.audience) return false
+        if (expiration != other.expiration) return false
+        if (notBefore != other.notBefore) return false
+        if (issuedAt != other.issuedAt) return false
+        if (cwtId != null) {
+            if (other.cwtId == null) return false
+            if (!cwtId.contentEquals(other.cwtId)) return false
+        } else if (other.cwtId != null) return false
+        if (nonce != null) {
+            if (other.nonce == null) return false
+            if (!nonce.contentEquals(other.nonce)) return false
+        } else if (other.nonce != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = issuer?.hashCode() ?: 0
+        result = 31 * result + (subject?.hashCode() ?: 0)
+        result = 31 * result + (audience?.hashCode() ?: 0)
+        result = 31 * result + (expiration?.hashCode() ?: 0)
+        result = 31 * result + (notBefore?.hashCode() ?: 0)
+        result = 31 * result + (issuedAt?.hashCode() ?: 0)
+        result = 31 * result + (cwtId?.contentHashCode() ?: 0)
+        result = 31 * result + (nonce?.contentHashCode() ?: 0)
+        return result
+    }
+
+    companion object {
+        fun deserialize(it: ByteArray) = runCatching {
+            cborSerializer.decodeFromByteArray<CborWebToken>(it)
+        }.wrap()
+    }
+}

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseHeader.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseHeader.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.cose
 
+import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
 import io.github.aakira.napier.Napier
 import io.matthewnelson.encoding.base16.Base16
@@ -93,10 +94,10 @@ data class CoseHeader(
         return "CoseHeader(algorithm=$algorithm," +
                 " criticalHeaders=$criticalHeaders," +
                 " contentType=$contentType," +
-                " kid=${kid?.encodeToString(Base16(strict = true))}," +
-                " iv=${iv?.encodeToString(Base16(strict = true))}," +
-                " partialIv=${partialIv?.encodeToString(Base16(strict = true))}," +
-                " certificateChain=${certificateChain?.encodeToString(Base16(strict = true))})"
+                " kid=${kid?.encodeToString(Base16Strict)}," +
+                " iv=${iv?.encodeToString(Base16Strict)}," +
+                " partialIv=${partialIv?.encodeToString(Base16Strict)}," +
+                " certificateChain=${certificateChain?.encodeToString(Base16Strict)})"
     }
 
     companion object {

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
@@ -8,6 +8,7 @@ import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
 import at.asitplus.crypto.datatypes.cose.CoseKey.Companion.deserialize
 import at.asitplus.crypto.datatypes.cose.CoseKeySerializer.CompressedCompoundCoseKeySerialContainer
 import at.asitplus.crypto.datatypes.cose.CoseKeySerializer.UncompressedCompoundCoseKeySerialContainer
+import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
 import at.asitplus.crypto.datatypes.misc.compressY
 import io.matthewnelson.encoding.base16.Base16
@@ -50,10 +51,10 @@ data class CoseKey(
 ) {
     override fun toString(): String {
         return "CoseKey(type=$type," +
-                " keyId=${keyId?.encodeToString(Base16(strict = true))}," +
+                " keyId=${keyId?.encodeToString(Base16Strict)}," +
                 " algorithm=$algorithm," +
                 " operations=${operations?.contentToString()}," +
-                " baseIv=${baseIv?.encodeToString(Base16(strict = true))}," +
+                " baseIv=${baseIv?.encodeToString(Base16Strict)}," +
                 keyParams.toString()
     }
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -2,6 +2,7 @@ package at.asitplus.crypto.datatypes.cose
 
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.CryptoSignature
+import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.github.aakira.napier.Napier
@@ -82,8 +83,8 @@ data class CoseSigned(
     override fun toString(): String {
         return "CoseSigned(protectedHeader=${protectedHeader.value}," +
                 " unprotectedHeader=$unprotectedHeader," +
-                " payload=${payload?.encodeToString(Base16(strict = true))}," +
-                " signature=${rawSignature.encodeToString(Base16(strict = true))})"
+                " payload=${payload?.encodeToString(Base16Strict)}," +
+                " signature=${rawSignature.encodeToString(Base16Strict)})"
     }
 
     companion object {
@@ -145,8 +146,8 @@ data class CoseSignatureInput(
     override fun toString(): String {
         return "CoseSignatureInput(contextString='$contextString'," +
                 " protectedHeader=${protectedHeader.value}," +
-                " externalAad=${externalAad.encodeToString(Base16(strict = true))}," +
-                " payload=${payload?.encodeToString(Base16(strict = true))})"
+                " externalAad=${externalAad.encodeToString(Base16Strict)}," +
+                " payload=${payload?.encodeToString(Base16Strict)})"
     }
 
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/InstantLongSerializer.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/InstantLongSerializer.kt
@@ -1,0 +1,23 @@
+package at.asitplus.crypto.datatypes.cose
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object InstantLongSerializer : KSerializer<Instant> {
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("InstantLongSerializer", PrimitiveKind.LONG)
+
+    override fun deserialize(decoder: Decoder): Instant {
+        return Instant.fromEpochSeconds(decoder.decodeLong())
+    }
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeLong(value.epochSeconds)
+    }
+
+}

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/io/Encodig.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/io/Encodig.kt
@@ -1,5 +1,7 @@
 package at.asitplus.crypto.datatypes.cose.io
 
+import io.matthewnelson.encoding.base16.Base16
+import io.matthewnelson.encoding.base16.Base16ConfigBuilder
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.cbor.Cbor
 
@@ -12,3 +14,11 @@ val cborSerializer by lazy {
         writeDefiniteLengths = true
     }
 }
+
+
+/**
+ * Strict Base16 encoder
+ */
+val Base16Strict = Base16(config = Base16ConfigBuilder().apply {
+    strict()
+}.build())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
@@ -254,7 +254,6 @@ data class X509Certificate(
          * or by decoding from Base64, or by decoding to a String, stripping PEM headers
          * (`-----BEGIN CERTIFICATE-----`) and then decoding from Base64.
          */
-        @Throws(Asn1Exception::class)
         fun decodeFromByteArray(src: ByteArray): X509Certificate? = runCatching {
             X509Certificate.decodeFromTlv(Asn1Element.parse(src) as Asn1Sequence)
         }.getOrNull() ?: runCatching {


### PR DESCRIPTION
Implement CBOR Web Token from [RFC 8392](https://datatracker.ietf.org/doc/html/rfc8392), to be used in [OpenID for Verifiable Credenital Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#authorization-details)