### PR TITLE
rework certificate handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,4 +86,13 @@
  * Boolean ASN.1 decoding helper function
  * Certificate to/from JCA certificate conversion functions
 
-### NEXT
+## 3.0
+
+### 3.0.0
+- Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
+- Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
+- Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
+- SubjectAltNames and IssuerAltNames:
+  - Perform some Structural validations on SAN and IAN
+  - Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
+    `AlternativeNames` structures for easy access to `dnsName`. `iPAddress`, etc.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ val signatureAlgorithm = JwsAlgorithm.ES256
 
 val tbsCsr = TbsCertificationRequest(
     version = 0,
-    subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+    subjectName = listOf(DistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
     publicKey = cryptoPublicKey
 )
 val signed =  /* pass tbsCsr.encodeToDer() to platform code*/

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
@@ -4,6 +4,7 @@ package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
+import at.asitplus.crypto.datatypes.jws.io.InstantLongSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/InstantLongSerializer.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/InstantLongSerializer.kt
@@ -1,4 +1,4 @@
-package at.asitplus.crypto.datatypes.jws
+package at.asitplus.crypto.datatypes.jws.io
 
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
@@ -1,0 +1,27 @@
+package at.asitplus.crypto.datatypes.jws.io
+
+import at.asitplus.crypto.datatypes.pki.X509Certificate
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+object JwsCertificateSerializer : KSerializer<X509Certificate> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor(serialName = "X509Certificate (JWS)", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): X509Certificate {
+        @OptIn(ExperimentalEncodingApi::class)
+        return X509Certificate.decodeFromDer(Base64.decode(decoder.decodeString()))
+    }
+
+
+    override fun serialize(encoder: Encoder, value: X509Certificate) {
+        @OptIn(ExperimentalEncodingApi::class)
+        encoder.encodeString(Base64.encode(value.encodeToDer()))
+    }
+}

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
@@ -210,6 +210,7 @@ class Asn1Sequence internal constructor(children: List<Asn1Element>) : Asn1Struc
  * ASN.1 OCTET STRING 0x04 ([BERTags.OCTET_STRING]) containing an [Asn1Element]
  * @param children the elements to put into this sequence
  */
+@Serializable(with = Asn1EncodableSerializer::class)
 class Asn1EncapsulatingOctetString(children: List<Asn1Element>) : Asn1Structure(BERTags.OCTET_STRING, children),
     Asn1OctetString<Asn1EncapsulatingOctetString> {
     override val content: ByteArray by lazy {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
@@ -92,7 +92,6 @@ private constructor(private val extensions: List<Asn1Element>) {
         }.map { (it as Asn1Primitive).content.decodeToString() }
 
     override fun toString(): String {
-        //StringBuilder()
         val bld =
             StringBuilder("\notherNames=").append(otherNames.joinToString { it.prettyPrint() })
         bld.append("\nrfc822Names=").append(rfc822Names?.joinToString())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
@@ -1,0 +1,144 @@
+package at.asitplus.crypto.datatypes.pki
+
+import at.asitplus.crypto.datatypes.asn1.*
+import at.asitplus.crypto.datatypes.asn1.DERTags.toImplicitTag
+import at.asitplus.crypto.datatypes.pki.AlternativeNames.Companion.findIssuerAltNames
+import at.asitplus.crypto.datatypes.pki.AlternativeNames.Companion.findSubjectAltNames
+
+
+/**
+ * [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) {Subject||Issuer}AlternativeNames (SANs, IANs)
+ * container class constructed from a certificate's [extensions] (i.e. [TbsCertificate.extensions] filtered by OID).
+ * Hence, this class is not intended to be used for constructing SANs or IANs, but used to extract them from a certificate.
+ *
+ * As this class performs some structural validations upon initialisation, it may throw various kinds of [Throwable]s.
+ * These are **not** limited to [Asn1Exception]s, which is why constructor invocation should be wrapped inside
+ * a [runRethrowing] block, as done in [findSubjectAltNames] and [findIssuerAltNames].
+ *
+ * See [RFC 5280, Section 4.2.1.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6)
+ * for details on the properties of this container class, as they are named accordingly.
+ */
+data class AlternativeNames
+@Throws(Throwable::class)
+private constructor(private val extensions: List<Asn1Element>) {
+
+    val dnsNames: List<String>? = parseStringSANs(SubjectAltNameImplicitTags.dNSName)
+    val rfc822Names: List<String>? = parseStringSANs(SubjectAltNameImplicitTags.rfc822Name)
+    val uris: List<String>? = parseStringSANs(SubjectAltNameImplicitTags.uniformResourceIdentifier)
+
+    val ipAddresses: List<ByteArray> = extensions.filter { it.tag == SubjectAltNameImplicitTags.iPAddress }.apply {
+        forEach {
+            if (it !is Asn1Primitive)
+                throw Asn1StructuralException("Invalid iPAddress Alternative Name found: ${it.toDerHexString()}")
+            else if (it.content.size != 4 && it.content.size != 16) throw Asn1StructuralException("Invalid iPAddress Alternative Name found: ${it.toDerHexString()}")
+        }
+    }.map { (it as Asn1Primitive).content }
+
+    val directoryNames: List<List<DistinguishedName>> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.directoryName }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid directoryName Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map { (it as Asn1Sequence).children.map { DistinguishedName.decodeFromTlv(it as Asn1Set) } }
+
+    val otherNames: List<Asn1Sequence> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.otherName }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid otherName Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map {
+            (it as Asn1Sequence).also {
+                if (it.children.size != 2) throw Asn1StructuralException("Invalid otherName Alternative Name found (!=2 children): ${it.toDerHexString()}")
+                if (it.children.last().tag != 0u.toImplicitTag()) throw Asn1StructuralException("Invalid otherName Alternative Name found (implicit tag != 0): ${it.toDerHexString()}")
+                ObjectIdentifier.parse((it.children.first() as Asn1Primitive).content) //this throws if something is off
+            }
+        }
+    val ediPartyNames: List<Asn1Sequence> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.ediPartyName }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid ediPartyName Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map {
+            (it as Asn1Sequence).also {
+                if (it.children.size > 2) throw Asn1StructuralException("Invalid partyName Alternative Name found (>2 children): ${it.toDerHexString()}")
+                if (it.children.find { it.tag != 0u.toImplicitTag() && it.tag != 1u.toImplicitTag() } != null) throw Asn1StructuralException(
+                    "Invalid partyName Alternative Name found (illegal implicit tag): ${it.toDerHexString()}"
+                )
+                //TODO: strict string parsing
+            }
+        }
+
+    val x400Addresses: List<Asn1Sequence> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.x400Address }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid x400Address Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map {
+            (it as Asn1Sequence).also {
+                //TODO: strict structural parsing
+            }
+        }
+
+    val registeredIDs: List<ObjectIdentifier> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.registeredID }.apply {
+            forEach {
+                if (it !is Asn1Primitive) throw Asn1StructuralException("Invalid registeredID Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map { ObjectIdentifier.parse((it as Asn1Primitive).content) }
+
+    private fun parseStringSANs(implicitTag: UByte) =
+        extensions.filter { it.tag == implicitTag }.apply {
+            forEach { if (it !is Asn1Primitive) throw Asn1StructuralException("Invalid dnsName Alternative Name found: ${it.toDerHexString()}") }
+        }.map { (it as Asn1Primitive).content.decodeToString() }
+
+    override fun toString(): String {
+        //StringBuilder()
+        val bld =
+            StringBuilder("\notherNames=").append(otherNames.joinToString { it.prettyPrint() })
+        bld.append("\nrfc822Names=").append(rfc822Names?.joinToString())
+        bld.append("\ndnsNames=").append(dnsNames?.joinToString())
+        bld.append("\nx400addresses=").append(x400Addresses.joinToString { it.prettyPrint() })
+        bld.append("\ndirectoryNames=").append(directoryNames.joinToString())
+        bld.append("\nediPartyNames=").append(ediPartyNames.joinToString { it.prettyPrint() })
+        bld.append("\nuris=").append(uris?.joinToString())
+        @OptIn(ExperimentalStdlibApi::class)
+        bld.append("\nipAddresses=").append(ipAddresses.joinToString { it.toHexString(HexFormat.UpperCase) })
+        bld.append("\nregisteredIDs=").append(registeredIDs.joinToString())
+        return "AlternativeNames(" + bld.toString().prependIndent("  ") + "\n)"
+    }
+
+    companion object {
+        @Throws(Asn1Exception::class)
+        fun List<X509CertificateExtension>.findSubjectAltNames() = runRethrowing {
+            find(KnownOIDs.subjectAltName_2_5_29_17)?.let { AlternativeNames(it) }
+        }
+
+        @Throws(Asn1Exception::class)
+        fun List<X509CertificateExtension>.findIssuerAltNames() = runRethrowing {
+            find(KnownOIDs.issuerAltName_2_5_29_18)?.let { AlternativeNames(it) }
+        }
+
+        /**not for public use, since it forces [Asn1EncapsulatingOctetString]*/
+        private fun List<X509CertificateExtension>.find(oid: ObjectIdentifier): List<Asn1Element>? {
+            val matches = filter { it.oid == oid }
+            if (matches.size > 1) throw Asn1StructuralException("More than one extension with oid $oid found")
+            return if (matches.isEmpty()) null
+            else ((matches.first().value as Asn1EncapsulatingOctetString).children?.firstOrNull() as Asn1Sequence?)?.children
+        }
+    }
+}
+
+/**
+ * Enumeration of implicit tags used to indicate different `SubjectAltName`s
+ */
+object SubjectAltNameImplicitTags {
+    val otherName = 0u.toImplicitTag()
+    val rfc822Name = 1u.toImplicitTag()
+    val dNSName = 2u.toImplicitTag()
+    val x400Address = 3u.toImplicitTag()
+    val directoryName = 4u.toImplicitTag()
+    val ediPartyName = 5u.toImplicitTag()
+    val uniformResourceIdentifier = 6u.toImplicitTag()
+    val iPAddress = 7u.toImplicitTag()
+    val registeredID = 8u.toImplicitTag()
+}

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
@@ -34,12 +34,12 @@ private constructor(private val extensions: List<Asn1Element>) {
         }
     }.map { (it as Asn1Primitive).content }
 
-    val directoryNames: List<List<DistinguishedName>> =
+    val directoryNames: List<List<RelativeDistinguishedName>> =
         extensions.filter { it.tag == SubjectAltNameImplicitTags.directoryName }.apply {
             forEach {
                 if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid directoryName Alternative Name found: ${it.toDerHexString()}")
             }
-        }.map { (it as Asn1Sequence).children.map { DistinguishedName.decodeFromTlv(it as Asn1Set) } }
+        }.map { (it as Asn1Sequence).children.map { RelativeDistinguishedName.decodeFromTlv(it as Asn1Set) } }
 
     val otherNames: List<Asn1Sequence> =
         extensions.filter { it.tag == SubjectAltNameImplicitTags.otherName }.apply {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TbsCertificationRequest(
     val version: Int = 0,
-    val subjectName: List<DistinguishedName>,
+    val subjectName: List<RelativeDistinguishedName>,
     val publicKey: CryptoPublicKey,
     val attributes: List<Pkcs10CertificationRequestAttribute>? = null
 ) : Asn1Encodable<Asn1Sequence> {
@@ -42,7 +42,7 @@ data class TbsCertificationRequest(
      */
     @Throws(IllegalArgumentException::class)
     constructor(
-        subjectName: List<DistinguishedName>,
+        subjectName: List<RelativeDistinguishedName>,
         publicKey: CryptoPublicKey,
         extensions: List<X509CertificateExtension>,
         version: Int = 0,
@@ -91,7 +91,7 @@ data class TbsCertificationRequest(
         override fun decodeFromTlv(src: Asn1Sequence) = runRethrowing {
             val version = (src.nextChild() as Asn1Primitive).readInt()
             val subject = (src.nextChild() as Asn1Sequence).children.map {
-                DistinguishedName.decodeFromTlv(it as Asn1Set)
+                RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)
             }
             val cryptoPublicKey = CryptoPublicKey.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val attributes = if (src.hasMoreChildren()) {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
@@ -25,10 +25,10 @@ constructor(
     val version: Int = 2,
     @Serializable(with = ByteArrayBase64Serializer::class) val serialNumber: ByteArray,
     val signatureAlgorithm: CryptoAlgorithm,
-    val issuerName: List<DistinguishedName>,
+    val issuerName: List<RelativeDistinguishedName>,
     val validFrom: Asn1Time,
     val validUntil: Asn1Time,
-    val subjectName: List<DistinguishedName>,
+    val subjectName: List<RelativeDistinguishedName>,
     val publicKey: CryptoPublicKey,
     val issuerUniqueID: BitSet? = null,
     val subjectUniqueID: BitSet? = null,
@@ -153,12 +153,12 @@ constructor(
             val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
             val sigAlg = CryptoAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val issuerNames = (src.nextChild() as Asn1Sequence).children.map {
-                DistinguishedName.decodeFromTlv(it as Asn1Set)
+                RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)
             }
 
             val timestamps = decodeTimestamps(src.nextChild() as Asn1Sequence)
             val subject = (src.nextChild() as Asn1Sequence).children.map {
-                DistinguishedName.decodeFromTlv(it as Asn1Set)
+                RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)
             }
 
             val cryptoPublicKey = CryptoPublicKey.decodeFromTlv(src.nextChild() as Asn1Sequence)

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/DistinguishedNameTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/DistinguishedNameTest.kt
@@ -1,11 +1,11 @@
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.KnownOIDs
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.CommonName
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.Country
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.Organization
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.OrganizationalUnit
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.Other
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.CommonName
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Country
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Organization
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.OrganizationalUnit
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Other
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Pkcs10CertificationRequestJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Pkcs10CertificationRequestJvmTest.kt
@@ -10,11 +10,7 @@ import at.asitplus.crypto.datatypes.asn1.ObjectIdentifier
 import at.asitplus.crypto.datatypes.asn1.encodeToTlv
 import at.asitplus.crypto.datatypes.asn1.ensureSize
 import at.asitplus.crypto.datatypes.asn1.parse
-import at.asitplus.crypto.datatypes.pki.DistinguishedName
-import at.asitplus.crypto.datatypes.pki.Pkcs10CertificationRequest
-import at.asitplus.crypto.datatypes.pki.Pkcs10CertificationRequestAttribute
-import at.asitplus.crypto.datatypes.pki.TbsCertificationRequest
-import at.asitplus.crypto.datatypes.pki.X509CertificateExtension
+import at.asitplus.crypto.datatypes.pki.*
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -68,7 +64,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
 
         val tbsCsr = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf( RelativeDistinguishedName(listOf(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName))))),
             publicKey = cryptoPublicKey
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
@@ -109,7 +105,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
             .build(contentSigner)
         val tbsCsr = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName( listOf(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName))))),
             publicKey = cryptoPublicKey,
             attributes = listOf(
                 Pkcs10CertificationRequestAttribute(KnownOIDs.keyUsage, Asn1Element.parse(keyUsage.encoded)),
@@ -157,7 +153,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
             .addAttribute(ASN1ObjectIdentifier("1.2.1840.13549.1.9.16.1337.26"), ASN1Integer(1337L))
             .build(contentSigner)
         val tbsCsr = TbsCertificationRequest(
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey,
             extensions = listOf(
                 X509CertificateExtension(
@@ -212,7 +208,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
         //x509Certificate.encodeToDer() shouldBe certificateHolder.encoded
         csr.signatureAlgorithm shouldBe signatureAlgorithm
         csr.tbsCsr.version shouldBe 0
-        (csr.tbsCsr.subjectName.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
+        (csr.tbsCsr.subjectName.first().attrsAndValues.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
         val parsedPublicKey = csr.tbsCsr.publicKey
         parsedPublicKey.shouldBeInstanceOf<CryptoPublicKey.Ec>()
         parsedPublicKey.x shouldBe keyX
@@ -236,37 +232,37 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
 
         val tbsCsr1 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey1
         )
         val tbsCsr11 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey1
         )
         val tbsCsr111 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName1))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName1)))),
             publicKey = cryptoPublicKey1
         )
         val tbsCsr12 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey11
         )
         val tbsCsr122 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName1))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName1)))),
             publicKey = cryptoPublicKey11
         )
         val tbsCsr2 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey2
         )
         val tbsCsr22 = TbsCertificationRequest(
             version = 1,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey2
         )
 

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
@@ -1,8 +1,6 @@
 package at.asitplus.crypto.datatypes
 
-import at.asitplus.crypto.datatypes.asn1.Asn1Element
-import at.asitplus.crypto.datatypes.asn1.Asn1Sequence
-import at.asitplus.crypto.datatypes.asn1.parse
+import at.asitplus.crypto.datatypes.asn1.*
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
@@ -52,6 +50,8 @@ class X509CertParserTest : FreeSpec({
                         "Actual: ${cert.encodeToDer().encodeToString(Base16)}"
             ) {
                 cert.encodeToTlv().derEncoded shouldBe jcaCert.encoded
+
+                cert shouldBe X509Certificate.decodeFromByteArray(certBytes)
             }
         }
     }
@@ -87,6 +87,7 @@ class X509CertParserTest : FreeSpec({
                 "Expect: ${crt.encoded.encodeToString(Base16)}\n" + "Actual: ${own.encodeToString(Base16)}"
             ) {
                 own shouldBe crt.encoded
+                own shouldBe X509Certificate.decodeFromByteArray(crt.encoded)
             }
         }
     }
@@ -101,7 +102,8 @@ class X509CertParserTest : FreeSpec({
 
             withData(nameFn = { it.first }, good) {
                 val src = Asn1Element.parse(it.second) as Asn1Sequence
-                X509Certificate.decodeFromTlv(src)
+                val decoded = X509Certificate.decodeFromTlv(src)
+                decoded shouldBe X509Certificate.decodeFromByteArray(it.second)
             }
         }
         "Faulty certs should glitch out" - {

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
@@ -1,10 +1,7 @@
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.*
-import at.asitplus.crypto.datatypes.pki.DistinguishedName
-import at.asitplus.crypto.datatypes.pki.TbsCertificate
-import at.asitplus.crypto.datatypes.pki.X509Certificate
-import at.asitplus.crypto.datatypes.pki.X509CertificateExtension
+import at.asitplus.crypto.datatypes.pki.*
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -74,11 +71,11 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = Asn1Time(notBeforeDate.toInstant().toKotlinInstant()),
             validUntil = Asn1Time(notAfterDate.toInstant().toKotlinInstant()),
             signatureAlgorithm = signatureAlgorithm,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
@@ -120,11 +117,11 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = Asn1Time(notBeforeDate.toInstant().toKotlinInstant()),
             validUntil = Asn1Time(notAfterDate.toInstant().toKotlinInstant()),
             signatureAlgorithm = signatureAlgorithm,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
@@ -167,8 +164,8 @@ class X509CertificateJvmTest : FreeSpec({
         //x509Certificate.encodeToDer() shouldBe certificateHolder.encoded
         x509Certificate.signatureAlgorithm shouldBe signatureAlgorithm
         x509Certificate.tbsCertificate.version shouldBe 2
-        (x509Certificate.tbsCertificate.issuerName.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
-        (x509Certificate.tbsCertificate.subjectName.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
+        (x509Certificate.tbsCertificate.issuerName.first().attrsAndValues.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
+        (x509Certificate.tbsCertificate.subjectName.first().attrsAndValues.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
         x509Certificate.tbsCertificate.serialNumber shouldBe serialNumber.toByteArray()
         x509Certificate.tbsCertificate.signatureAlgorithm shouldBe signatureAlgorithm
         x509Certificate.tbsCertificate.validFrom.instant shouldBe notBeforeDate.toInstant()
@@ -273,53 +270,53 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate1 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate2 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate3 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm512,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate4 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8("DefaultCryptoService1"))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8("DefaultCryptoService1")))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate5 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = Asn1Time(Date.from(Instant.now().plusSeconds(1)).toInstant().toKotlinInstant()),
             validUntil = Asn1Time(
                 Date.from(Instant.now().plusSeconds(30.days.inWholeSeconds)).toInstant().toKotlinInstant()
             ),
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
 
@@ -420,11 +417,11 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate6 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey,
             extensions = listOf(ext1)
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion = 2.7.0-SNAPSHOT
+artifactVersion = 3.0.0-SNAPSHOT
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
 


### PR DESCRIPTION
* JwsHeader now contains CertificateChain

 * Certificate SANs and IANs can now be parsed.

* Fix RelativeDistinguishedName structure

Tested only using certs from resources (none fail, but they don't cover everything). Still, if it is good enough for Google, it should e good enough for us