### PR TITLE
Release/3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
  * Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects
  * Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`
  * Support more JWE algorithms, e.g. AES
+ * Add `header` to constructor parameters of `JweEncrypted`
  * Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
  * Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
  * Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
  * Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`
  * Support more JWE algorithms, e.g. AES
  * Add `header` to constructor parameters of `JweEncrypted`
+ * Extend properties of `JsonWebKey`
  * Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
  * Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
  * Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 
 ### 3.0.0
 * Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects
+* Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`
 * Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
 * Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
 * Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,5 @@
  * Implement `CborWebToken` (RFC 8392)
  * Boolean ASN.1 decoding helper function
  * Certificate to/from JCA certificate conversion functions
+
+### NEXT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,10 +89,11 @@
 ## 3.0
 
 ### 3.0.0
-- Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
-- Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
-- Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
-- SubjectAltNames and IssuerAltNames:
-  - Perform some Structural validations on SAN and IAN
-  - Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
+* Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects
+* Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
+* Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
+* Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
+* SubjectAltNames and IssuerAltNames:
+  * Perform some Structural validations on SAN and IAN
+  * Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
     `AlternativeNames` structures for easy access to `dnsName`. `iPAddress`, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,15 +89,26 @@
 ## 3.0
 
 ### 3.0.0
- * Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects
- * Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`
+
+**Fixes**
+ * Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
+ * Fix `Asn1Time` not truncating to seconds
+ * Fix parsing of CryptoSignature when decoding Certificates
+ * Remove bogus `serialize()` function from `CryptoSignature`  **THIS IS A BREAKING CHANGE**
+
+
+**Features**
+ * Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects  **THIS IS A BREAKING CHANGE**
+ * Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`  **THIS IS A BREAKING CHANGE**
  * Support more JWE algorithms, e.g. AES
  * Add `header` to constructor parameters of `JweEncrypted`
  * Extend properties of `JsonWebKey`
  * Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
  * Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
- * Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
+ * Use `CertificateChain` inside `JsonWebKey` instead of `Array<ByteArray>'
+
  * SubjectAltNames and IssuerAltNames:
-    * Perform some Structural validations on SAN and IAN
+    * Perform some structural validations on SAN and IAN
     * Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
       `AlternativeNames` structures for easy access to `dnsName`. `iPAddress`, etc.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,4 +86,13 @@
  * Boolean ASN.1 decoding helper function
  * Certificate to/from JCA certificate conversion functions
 
-### NEXT
+## 3.0
+
+### 3.0.0
+- Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
+- Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
+- Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
+- SubjectAltNames and IssuerAltNames:
+  - Perform some Structural validations on SAN and IAN
+  - Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
+    `AlternativeNames` structures for easy access to `dnsName`. `iPAddress`, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,12 +89,13 @@
 ## 3.0
 
 ### 3.0.0
-* Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects
-* Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`
-* Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
-* Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
-* Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
-* SubjectAltNames and IssuerAltNames:
-  * Perform some Structural validations on SAN and IAN
-  * Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
-    `AlternativeNames` structures for easy access to `dnsName`. `iPAddress`, etc.
+ * Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects
+ * Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`
+ * Support more JWE algorithms, e.g. AES
+ * Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
+ * Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
+ * Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
+ * SubjectAltNames and IssuerAltNames:
+    * Perform some Structural validations on SAN and IAN
+    * Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
+      `AlternativeNames` structures for easy access to `dnsName`. `iPAddress`, etc.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ val signatureAlgorithm = JwsAlgorithm.ES256
 
 val tbsCsr = TbsCertificationRequest(
     version = 0,
-    subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+    subjectName = listOf(DistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
     publicKey = cryptoPublicKey
 )
 val signed =  /* pass tbsCsr.encodeToDer() to platform code*/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ types and functionality related to crypto and PKI applications:
 * Generic ASN.1 abstractions to operate on and create arbitrary ASN.1 Data
 * JWS-related data structures (JSON Web Keys, JWT, etc…)
 * COSE-related data structures (COSE Keys, CWT, etc…)
-* Serializability of all data classes for debugging
+* Serializability of all ASN.1 classes for debugging **AND ONLY FOR DEBUGGING!!!** *Seriously, do not try to deserialize ASN.1 classes through kotlinx.serialization! Use `decodeFromDer()` and its companions!*
 * 100% pure Kotlin BitSet
 * **ASN.1 Parser and Encoder including a DSL to generate ASN.1 structures**
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseHeader.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseHeader.kt
@@ -1,9 +1,8 @@
 package at.asitplus.crypto.datatypes.cose
 
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
-import io.github.aakira.napier.Napier
-import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -103,9 +102,6 @@ data class CoseHeader(
     companion object {
         fun deserialize(it: ByteArray) = kotlin.runCatching {
             cborSerializer.decodeFromByteArray<CoseHeader>(it)
-        }.getOrElse {
-            Napier.w("deserialize failed", it)
-            null
-        }
+        }.wrap()
     }
 }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -1,12 +1,11 @@
 package at.asitplus.crypto.datatypes.cose
 
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.CryptoSignature
 import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
 import at.asitplus.crypto.datatypes.pki.X509Certificate
-import io.github.aakira.napier.Napier
-import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
@@ -90,10 +89,7 @@ data class CoseSigned(
     companion object {
         fun deserialize(it: ByteArray) = kotlin.runCatching {
             cborSerializer.decodeFromByteArray<CoseSigned>(it)
-        }.getOrElse {
-            Napier.w("deserialize failed", it)
-            null
-        }
+        }.wrap()
     }
 }
 
@@ -154,10 +150,7 @@ data class CoseSignatureInput(
     companion object {
         fun deserialize(it: ByteArray) = kotlin.runCatching {
             cborSerializer.decodeFromByteArray<CoseSignatureInput>(it)
-        }.getOrElse {
-            Napier.w("deserialize failed", it)
-            null
-        }
+        }.wrap()
     }
 }
 

--- a/datatypes-cose/src/commonTest/kotlin/at/asitplus/crypto/datatypes/cose/CoseSerializationTest.kt
+++ b/datatypes-cose/src/commonTest/kotlin/at/asitplus/crypto/datatypes/cose/CoseSerializationTest.kt
@@ -34,8 +34,8 @@ class CoseSerializationTest : FreeSpec({
         val serialized = header.serialize().encodeToString(Base16(strict = true)).uppercase()
         println(serialized)
 
-        val deserialized = CoseHeader.deserialize(header.serialize())
-        deserialized.shouldNotBeNull()
+        val deserialized = CoseHeader.deserialize(header.serialize()).getOrThrow().shouldNotBeNull()
+
         deserialized.algorithm shouldBe header.algorithm
         deserialized.kid shouldBe header.kid
     }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -1,3 +1,4 @@
+@file:UseSerializers(JwsCertificateSerializer::class)
 package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.KmmResult
@@ -10,12 +11,14 @@ import at.asitplus.crypto.datatypes.io.Base64Strict
 import at.asitplus.crypto.datatypes.io.Base64UrlStrict
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64UrlSerializer
+import at.asitplus.crypto.datatypes.jws.io.JwsCertificateSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import at.asitplus.crypto.datatypes.pki.CertificateChain
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okio.ByteString.Companion.toByteString

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -11,6 +11,7 @@ import at.asitplus.crypto.datatypes.io.Base64UrlStrict
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64UrlSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
+import at.asitplus.crypto.datatypes.pki.CertificateChain
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.SerialName
@@ -152,7 +153,7 @@ data class JsonWebKey(
      * OPTIONAL.
      */
     @SerialName("x5c")
-    val certificateChain: List<X509Certificate>? = null,
+    val certificateChain: CertificateChain? = null,
 
     /**
      * The "x5t" (X.509 certificate SHA-1 thumbprint) parameter is a

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -11,6 +11,7 @@ import at.asitplus.crypto.datatypes.io.Base64UrlStrict
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64UrlSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
+import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -151,7 +152,7 @@ data class JsonWebKey(
      * OPTIONAL.
      */
     @SerialName("x5c")
-    val certificateChain: List<@Serializable(with = ByteArrayBase64Serializer::class) ByteArray>? = null,
+    val certificateChain: List<X509Certificate>? = null,
 
     /**
      * The "x5t" (X.509 certificate SHA-1 thumbprint) parameter is a
@@ -201,7 +202,7 @@ data class JsonWebKey(
                 " keyOperations=$keyOperations," +
                 " algorithm=$algorithm," +
                 " certificateUrl=$certificateUrl," +
-                " certificateChain=${certificateChain?.joinToString { it.encodeToString(Base64Strict) }}," +
+                " certificateChain=${certificateChain}," +
                 " certificateSha1Thumbprint=${certificateSha1Thumbprint?.encodeToString(Base64UrlStrict)}," +
                 " certificateSha256Thumbprint=${certificateSha256Thumbprint?.encodeToString(Base64UrlStrict)})"
     }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -7,6 +7,8 @@ import at.asitplus.crypto.datatypes.EcCurve
 import at.asitplus.crypto.datatypes.asn1.decodeFromDer
 import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
 import at.asitplus.crypto.datatypes.io.Base64Strict
+import at.asitplus.crypto.datatypes.io.Base64UrlStrict
+import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64UrlSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -21,28 +23,159 @@ import okio.ByteString.Companion.toByteString
  */
 @Serializable
 data class JsonWebKey(
+    /**
+     * Set for EC keys only
+     */
     @SerialName("crv")
     val curve: EcCurve? = null,
+
+    /**
+     * The "kty" (key type) parameter identifies the cryptographic algorithm
+     * family used with the key, such as "RSA" or "EC".  "kty" values should
+     * either be registered in the IANA "JSON Web Key Types" registry
+     * established by (JWA) or be a value that contains a Collision-
+     * Resistant Name.  The "kty" value is a case-sensitive string.  This
+     * member MUST be present in a JWK.
+     */
     @SerialName("kty")
     val type: JwkType? = null,
+
+    /**
+     * The "kid" (key ID) parameter is used to match a specific key.  This
+     * is used, for instance, to choose among a set of keys within a JWK Set
+     * during key rollover.  The structure of the "kid" value is
+     * unspecified.  When "kid" values are used within a JWK Set, different
+     * keys within the JWK Set SHOULD use distinct "kid" values.  (One
+     * example in which different keys might use the same "kid" value is if
+     * they have different "kty" (key type) values but are considered to be
+     * equivalent alternatives by the application using them.)  The "kid"
+     * value is a case-sensitive string.  Use of this member is OPTIONAL.
+     * When used with JWS or JWE, the "kid" value is used to match a JWS or
+     * JWE "kid" Header Parameter value.
+     */
     @SerialName("kid")
     val keyId: String? = null,
+
+    /**
+     * Set for EC keys only
+     */
     @SerialName("x")
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val x: ByteArray? = null,
+
+    /**
+     * Set for EC keys only
+     */
     @SerialName("y")
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val y: ByteArray? = null,
+
+    /**
+     * Set for RSA keys only
+     */
     @SerialName("n")
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val n: ByteArray? = null,
+
+    /**
+     * Set for RSA keys only
+     */
     @SerialName("e")
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val e: ByteArray? = null,
-    //Symmetric Key
+
+    /**
+     * Set for symmetric keys only
+     */
     @SerialName("k")
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val k: ByteArray? = null,
+
+    /**
+     * The "use" (public key use) parameter identifies the intended use of
+     * the public key.  The "use" parameter is employed to indicate whether
+     * a public key is used for encrypting data or verifying the signature
+     * on data.
+     */
+    @SerialName("use")
+    val publicKeyUse: String? = null,
+
+    /**
+     * The "key_ops" (key operations) parameter identifies the operation(s)
+     * for which the key is intended to be used.  The "key_ops" parameter is
+     * intended for use cases in which public, private, or symmetric keys
+     * may be present.
+     */
+    @SerialName("key_ops")
+    val keyOperations: Set<String>? = null,
+
+    /**
+     * The "alg" (algorithm) parameter identifies the algorithm intended for
+     * use with the key.  The values used should either be registered in the
+     * IANA "JSON Web Signature and Encryption Algorithms" registry
+     * established by [JWA] or be a value that contains a Collision-
+     * Resistant Name.  The "alg" value is a case-sensitive ASCII string.
+     * Use of this member is OPTIONAL.
+     */
+    @SerialName("alg")
+    val algorithm: JwsAlgorithm? = null,
+
+    /**
+     * The "x5u" (X.509 URL) parameter is a URI (RFC3986) that refers to a
+     * resource for an X.509 public key certificate or certificate chain
+     * (RFC5280).  The identified resource MUST provide a representation of
+     * the certificate or certificate chain that conforms to RFC 5280
+     * (RFC5280) in PEM-encoded form, with each certificate delimited as
+     * specified in Section 6.1 of RFC 4945 (RFC4945).  The key in the first
+     * certificate MUST match the public key represented by other members of
+     * the JWK.  The protocol used to acquire the resource MUST provide
+     * integrity protection; an HTTP GET request to retrieve the certificate
+     * MUST use TLS (RFC2818) (RFC5246); the identity of the server MUST be
+     * validated, as per Section 6 of RFC 6125 (RFC6125).  Use of this
+     * member is OPTIONAL.
+     */
+    @SerialName("x5u")
+    val certificateUrl: String? = null,
+
+    /**
+     * The "x5c" (X.509 certificate chain) parameter contains a chain of one
+     * or more PKIX certificates (RFC5280).  The certificate chain is
+     * represented as a JSON array of certificate value strings.  Each
+     * string in the array is a base64-encoded (Section 4 of (RFC4648) --
+     * not base64url-encoded) DER (ITU.X690.1994) PKIX certificate value.
+     * The PKIX certificate containing the key value MUST be the first
+     * certificate.  This MAY be followed by additional certificates, with
+     * each subsequent certificate being the one used to certify the
+     * previous one.  The key in the first certificate MUST match the public
+     * key represented by other members of the JWK.  Use of this member is
+     * OPTIONAL.
+     */
+    @SerialName("x5c")
+    val certificateChain: List<@Serializable(with = ByteArrayBase64Serializer::class) ByteArray>? = null,
+
+    /**
+     * The "x5t" (X.509 certificate SHA-1 thumbprint) parameter is a
+     * base64url-encoded SHA-1 thumbprint (a.k.a. digest) of the DER
+     * encoding of an X.509 certificate (RFC5280).  Note that certificate
+     * thumbprints are also sometimes known as certificate fingerprints.
+     * The key in the certificate MUST match the public key represented by
+     * other members of the JWK.  Use of this member is OPTIONAL.
+     */
+    @SerialName("x5t")
+    @Serializable(with = ByteArrayBase64UrlSerializer::class)
+    val certificateSha1Thumbprint: ByteArray? = null,
+
+    /**
+     * The "x5t#S256" (X.509 certificate SHA-256 thumbprint) parameter is a
+     * base64url-encoded SHA-256 thumbprint (a.k.a. digest) of the DER
+     * encoding of an X.509 certificate (RFC5280).  Note that certificate
+     * thumbprints are also sometimes known as certificate fingerprints.
+     * The key in the certificate MUST match the public key represented by
+     * other members of the JWK.  Use of this member is OPTIONAL.
+     */
+    @SerialName("x5t#S256")
+    @Serializable(with = ByteArrayBase64UrlSerializer::class)
+    val certificateSha256Thumbprint: ByteArray? = null,
 ) {
 
     val jwkThumbprint: String by lazy {
@@ -53,17 +186,25 @@ data class JsonWebKey(
         keyId ?: "urn:ietf:params:oauth:jwk-thumbprint:sha256:${jwkThumbprint}"
     }
 
-    override fun toString() =
-        "JsonWebKey(" +
-                "type=$type, " +
-                "curve=$curve, " +
-                "keyId=$keyId," +
-                "x=${x?.encodeToString(Base64Strict)}," +
-                "y=${y?.encodeToString(Base64Strict)}" +
-                "n=${n?.encodeToString(Base64Strict)})" +
-                "e=${e?.encodeToString(Base64Strict)}" +
-                "k=${k?.encodeToString(Base64Strict)}" +
-                ")"
+    fun serialize() = jsonSerializer.encodeToString(this)
+
+    override fun toString(): String {
+        return "JsonWebKey(curve=$curve," +
+                " type=$type," +
+                " keyId=$keyId," +
+                " x=${x?.encodeToString(Base64UrlStrict)}," +
+                " y=${y?.encodeToString(Base64UrlStrict)}," +
+                " n=${n?.encodeToString(Base64UrlStrict)}," +
+                " e=${e?.encodeToString(Base64UrlStrict)}," +
+                " k=${k?.encodeToString(Base64UrlStrict)}," +
+                " publicKeyUse=$publicKeyUse," +
+                " keyOperations=$keyOperations," +
+                " algorithm=$algorithm," +
+                " certificateUrl=$certificateUrl," +
+                " certificateChain=${certificateChain?.joinToString { it.encodeToString(Base64Strict) }}," +
+                " certificateSha1Thumbprint=${certificateSha1Thumbprint?.encodeToString(Base64UrlStrict)}," +
+                " certificateSha256Thumbprint=${certificateSha256Thumbprint?.encodeToString(Base64UrlStrict)})"
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -71,8 +212,8 @@ data class JsonWebKey(
 
         other as JsonWebKey
 
-        if (type != other.type) return false
         if (curve != other.curve) return false
+        if (type != other.type) return false
         if (keyId != other.keyId) return false
         if (x != null) {
             if (other.x == null) return false
@@ -82,7 +223,6 @@ data class JsonWebKey(
             if (other.y == null) return false
             if (!y.contentEquals(other.y)) return false
         } else if (other.y != null) return false
-
         if (n != null) {
             if (other.n == null) return false
             if (!n.contentEquals(other.n)) return false
@@ -95,24 +235,45 @@ data class JsonWebKey(
             if (other.k == null) return false
             if (!k.contentEquals(other.k)) return false
         } else if (other.k != null) return false
+        if (publicKeyUse != other.publicKeyUse) return false
+        if (keyOperations != other.keyOperations) return false
+        if (algorithm != other.algorithm) return false
+        if (certificateUrl != other.certificateUrl) return false
+        if (certificateChain != other.certificateChain) return false
+        if (certificateSha1Thumbprint != null) {
+            if (other.certificateSha1Thumbprint == null) return false
+            if (!certificateSha1Thumbprint.contentEquals(other.certificateSha1Thumbprint)) return false
+        } else if (other.certificateSha1Thumbprint != null) return false
+        if (certificateSha256Thumbprint != null) {
+            if (other.certificateSha256Thumbprint == null) return false
+            if (!certificateSha256Thumbprint.contentEquals(other.certificateSha256Thumbprint)) return false
+        } else if (other.certificateSha256Thumbprint != null) return false
+
         return true
     }
 
     override fun hashCode(): Int {
-        var result = type?.hashCode() ?: 0
-        result = 31 * result + (curve?.hashCode() ?: 0)
+        var result = curve?.hashCode() ?: 0
+        result = 31 * result + (type?.hashCode() ?: 0)
         result = 31 * result + (keyId?.hashCode() ?: 0)
         result = 31 * result + (x?.contentHashCode() ?: 0)
         result = 31 * result + (y?.contentHashCode() ?: 0)
-        result = 31 * result + (n?.hashCode() ?: 0)
-        result = 31 * result + (e?.hashCode() ?: 0)
-        result = 31 * result + (k?.hashCode() ?: 0)
+        result = 31 * result + (n?.contentHashCode() ?: 0)
+        result = 31 * result + (e?.contentHashCode() ?: 0)
+        result = 31 * result + (k?.contentHashCode() ?: 0)
+        result = 31 * result + (publicKeyUse?.hashCode() ?: 0)
+        result = 31 * result + (keyOperations?.hashCode() ?: 0)
+        result = 31 * result + (algorithm?.hashCode() ?: 0)
+        result = 31 * result + (certificateUrl?.hashCode() ?: 0)
+        result = 31 * result + (certificateChain?.hashCode() ?: 0)
+        result = 31 * result + (certificateSha1Thumbprint?.contentHashCode() ?: 0)
+        result = 31 * result + (certificateSha256Thumbprint?.contentHashCode() ?: 0)
         return result
     }
 
     /**
-     * @return a KmmResult wrapped [CryptoPublicKey] equivalent if conversion is possible (i.e. if all key params are set)
-     * or the first error.
+     * @return a KmmResult wrapped [CryptoPublicKey] equivalent if conversion is possible
+     * (i.e. if all key params are set), or the first error.
      */
     fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> =
         runCatching {
@@ -136,8 +297,6 @@ data class JsonWebKey(
                 else -> throw IllegalArgumentException("Illegal key type")
             }
         }.wrap()
-
-    fun serialize() = jsonSerializer.encodeToString(this)
 
     /**
      * Contains convenience functions

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKeySet.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKeySet.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.jws
 
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -16,12 +17,12 @@ data class JsonWebKeySet(
 
     fun serialize() = kotlin.runCatching {
         jsonSerializer.encodeToString(this)
-    }.getOrNull()
+    }.wrap()
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
             jsonSerializer.decodeFromString<JsonWebKeySet>(it)
-        }.getOrNull()
+        }.wrap()
     }
 
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
@@ -4,6 +4,7 @@ package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
+import at.asitplus.crypto.datatypes.jws.io.InstantLongSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweAlgorithm.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweAlgorithm.kt
@@ -11,6 +11,9 @@ import kotlinx.serialization.encoding.Encoder
 @Serializable(with = JweAlgorithmSerializer::class)
 enum class JweAlgorithm(val text: String) {
     ECDH_ES("ECDH-ES"),
+    A128KW("A128KW"),
+    A192KW("A192KW"),
+    A256KW("A256KW"),
     RSA_OAEP_256("RSA-OAEP-256"),
     RSA_OAEP_384("RSA-OAEP-384"),
     RSA_OAEP_512("RSA-OAEP-512")

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweDecrypted.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweDecrypted.kt
@@ -1,6 +1,4 @@
-package at.asitplus.wallet.lib.jws
-
-import at.asitplus.crypto.datatypes.jws.JweHeader
+package at.asitplus.crypto.datatypes.jws
 
 /**
  * Representation of a decrypted JSON Web Encryption object, i.e. header and payload.

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
@@ -16,14 +16,13 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
  * @see [JweDecrypted]
  */
 data class JweEncrypted(
+    val header: JweHeader,
     val headerAsParsed: ByteArray,
     val encryptedKey: ByteArray? = null,
     val iv: ByteArray,
     val ciphertext: ByteArray,
     val authTag: ByteArray
 ) {
-    val header: JweHeader?
-        get() = JweHeader.deserialize(headerAsParsed.decodeToString()).getOrNull()
 
     fun serialize(): String {
         return headerAsParsed.encodeToString(Base64UrlStrict) +
@@ -65,12 +64,13 @@ data class JweEncrypted(
         fun parse(it: String): KmmResult<JweEncrypted> = runCatching {
             val stringList = it.replace("[^A-Za-z0-9-_.]".toRegex(), "").split(".")
             if (stringList.size != 5) throw IllegalArgumentException("not five parts in input: $it")
-            val headerAsParsed = stringList[0].decodeToByteArray(Base64Strict)
-            val encryptedKey = stringList[1].decodeToByteArray(Base64Strict)
-            val iv = stringList[2].decodeToByteArray(Base64Strict)
-            val ciphertext = stringList[3].decodeToByteArray(Base64Strict)
-            val authTag = stringList[4].decodeToByteArray(Base64Strict)
-            JweEncrypted(headerAsParsed, encryptedKey, iv, ciphertext, authTag)
+            val headerAsParsed = stringList[0].decodeToByteArray(Base64UrlStrict)
+            val encryptedKey = stringList[1].decodeToByteArray(Base64UrlStrict)
+            val iv = stringList[2].decodeToByteArray(Base64UrlStrict)
+            val ciphertext = stringList[3].decodeToByteArray(Base64UrlStrict)
+            val authTag = stringList[4].decodeToByteArray(Base64UrlStrict)
+            val header = JweHeader.deserialize(headerAsParsed.decodeToString()).getOrThrow()
+            JweEncrypted(header, headerAsParsed, encryptedKey, iv, ciphertext, authTag)
         }.wrap()
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
@@ -22,7 +22,7 @@ data class JweEncrypted(
     val authTag: ByteArray
 ) {
     val header: JweHeader?
-        get() = JweHeader.deserialize(headerAsParsed.decodeToString())
+        get() = JweHeader.deserialize(headerAsParsed.decodeToString()).getOrNull()
 
     fun serialize(): String {
         return headerAsParsed.encodeToString(Base64UrlStrict) +

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
@@ -1,9 +1,10 @@
 package at.asitplus.crypto.datatypes.jws
 
+import at.asitplus.KmmResult
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.io.Base64Strict
 import at.asitplus.crypto.datatypes.io.Base64UrlStrict
-import io.github.aakira.napier.Napier
-import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 
 /**
@@ -61,19 +62,15 @@ data class JweEncrypted(
 
 
     companion object {
-        fun parse(it: String): JweEncrypted? {
+        fun parse(it: String): KmmResult<JweEncrypted> = runCatching {
             val stringList = it.replace("[^A-Za-z0-9-_.]".toRegex(), "").split(".")
-            if (stringList.size != 5) return null.also { Napier.w("Could not parse JWE: $it") }
-            val headerAsParsed = stringList[0].decodeToByteArrayOrNull(Base64Strict)
-                ?: return null.also { Napier.w("Could not parse JWE: $it") }
-            val encryptedKey = stringList[1].decodeToByteArrayOrNull(Base64Strict)
-            val iv = stringList[2].decodeToByteArrayOrNull(Base64Strict)
-                ?: return null.also { Napier.w("Could not parse JWE: $it") }
-            val ciphertext = stringList[3].decodeToByteArrayOrNull(Base64Strict)
-                ?: return null.also { Napier.w("Could not parse JWE: $it") }
-            val authTag = stringList[4].decodeToByteArrayOrNull(Base64Strict)
-                ?: return null.also { Napier.w("Could not parse JWE: $it") }
-            return JweEncrypted(headerAsParsed, encryptedKey, iv, ciphertext, authTag)
-        }
+            if (stringList.size != 5) throw IllegalArgumentException("not five parts in input: $it")
+            val headerAsParsed = stringList[0].decodeToByteArray(Base64Strict)
+            val encryptedKey = stringList[1].decodeToByteArray(Base64Strict)
+            val iv = stringList[2].decodeToByteArray(Base64Strict)
+            val ciphertext = stringList[3].decodeToByteArray(Base64Strict)
+            val authTag = stringList[4].decodeToByteArray(Base64Strict)
+            JweEncrypted(headerAsParsed, encryptedKey, iv, ciphertext, authTag)
+        }.wrap()
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncryption.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncryption.kt
@@ -12,19 +12,26 @@ import kotlinx.serialization.encoding.Encoder
  * Supported JWE algorithms.
  *
  * See [RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516)
+ * and also [RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518)
  */
 @Serializable(with = JweEncryptionSerializer::class)
 enum class JweEncryption(val text: String) {
 
+    A128GCM("A128GCM"),
+    A192GCM("A192GCM"),
     A256GCM("A256GCM");
 
     val encryptionKeyLength
         get() = when (this) {
+            A128GCM -> 128
+            A192GCM -> 192
             A256GCM -> 256
         }
 
     val ivLengthBits
         get() = when (this) {
+            A128GCM -> 128
+            A192GCM -> 192
             A256GCM -> 128
         }
 }
@@ -40,7 +47,7 @@ object JweEncryptionSerializer : KSerializer<JweEncryption?> {
 
     override fun deserialize(decoder: Decoder): JweEncryption? {
         val decoded = decoder.decodeString()
-        return JweEncryption.values().firstOrNull { it.text == decoded }
+        return JweEncryption.entries.firstOrNull { it.text == decoded }
     }
 }
 

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweHeader.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweHeader.kt
@@ -21,7 +21,7 @@ data class JweHeader(
     @SerialName("kid")
     val keyId: String? = null,
     @SerialName("typ")
-    val type: String?,
+    val type: String? = null,
     @SerialName("cty")
     val contentType: String? = null,
     @SerialName("jwk")

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweHeader.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweHeader.kt
@@ -1,8 +1,8 @@
 package at.asitplus.crypto.datatypes.jws
 
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64UrlSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
-import io.github.aakira.napier.Napier
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -82,9 +82,6 @@ data class JweHeader(
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
             jsonSerializer.decodeFromString<JweHeader>(it)
-        }.getOrElse {
-            Napier.w("deserialize failed", it)
-            null
-        }
+        }.wrap()
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsHeader.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsHeader.kt
@@ -2,15 +2,14 @@
 
 package at.asitplus.crypto.datatypes.jws
 
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.jws.io.InstantLongSerializer
 import at.asitplus.crypto.datatypes.jws.io.JwsCertificateSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import at.asitplus.crypto.datatypes.pki.CertificateChain
-import at.asitplus.crypto.datatypes.pki.X509Certificate
 import at.asitplus.crypto.datatypes.pki.leaf
-import io.github.aakira.napier.Napier
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -110,10 +109,7 @@ data class JwsHeader(
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
             jsonSerializer.decodeFromString<JwsHeader>(it)
-        }.getOrElse {
-            Napier.w("deserialize failed", it)
-            null
-        }
+        }.wrap()
 
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -68,6 +68,14 @@ data class JwsSigned(
         }.wrap()
 
 
+        /**
+         * Called by JWS signing implementations to get the string that will be
+         * used as the input for signature calculation
+         */
+        @Suppress("unused")
+        fun prepareJwsSignatureInput(header: JwsHeader, payload: ByteArray): String =
+            "${header.serialize().encodeToByteArray().encodeToString(Base64UrlStrict)}" +
+                    ".${payload.encodeToString(Base64UrlStrict)}"
     }
 }
 

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -54,7 +54,7 @@ data class JwsSigned(
             if (stringList.size != 3) return null.also { Napier.w("Could not parse JWS: $it") }
             val headerInput = stringList[0].decodeToByteArrayOrNull(Base64UrlStrict)
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
-            val header = JwsHeader.deserialize(headerInput.decodeToString())
+            val header = JwsHeader.deserialize(headerInput.decodeToString()).getOrNull()
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }
             val payload = stringList[1].decodeToByteArrayOrNull(Base64UrlStrict)
                 ?: return null.also { Napier.w("Could not parse JWS: $it") }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/InstantLongSerializer.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/InstantLongSerializer.kt
@@ -1,4 +1,4 @@
-package at.asitplus.crypto.datatypes.jws
+package at.asitplus.crypto.datatypes.jws.io
 
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
@@ -1,13 +1,15 @@
 package at.asitplus.crypto.datatypes.jws.io
 
+import at.asitplus.crypto.datatypes.io.Base64Strict
 import at.asitplus.crypto.datatypes.pki.X509Certificate
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 object JwsCertificateSerializer : KSerializer<X509Certificate> {
@@ -15,13 +17,11 @@ object JwsCertificateSerializer : KSerializer<X509Certificate> {
         PrimitiveSerialDescriptor(serialName = "X509Certificate (JWS)", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): X509Certificate {
-        @OptIn(ExperimentalEncodingApi::class)
-        return X509Certificate.decodeFromDer(Base64.decode(decoder.decodeString()))
+        return X509Certificate.decodeFromDer(decoder.decodeString().decodeToByteArray(Base64Strict))
     }
 
 
     override fun serialize(encoder: Encoder, value: X509Certificate) {
-        @OptIn(ExperimentalEncodingApi::class)
-        encoder.encodeString(Base64.encode(value.encodeToDer()))
+        encoder.encodeString(value.encodeToDer().encodeToString(Base64Strict))
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
@@ -1,0 +1,27 @@
+package at.asitplus.crypto.datatypes.jws.io
+
+import at.asitplus.crypto.datatypes.pki.X509Certificate
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+object JwsCertificateSerializer : KSerializer<X509Certificate> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor(serialName = "X509Certificate (JWS)", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): X509Certificate {
+        @OptIn(ExperimentalEncodingApi::class)
+        return X509Certificate.decodeFromDer(Base64.decode(decoder.decodeString()))
+    }
+
+
+    override fun serialize(encoder: Encoder, value: X509Certificate) {
+        @OptIn(ExperimentalEncodingApi::class)
+        encoder.encodeString(Base64.encode(value.encodeToDer()))
+    }
+}

--- a/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
+++ b/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
@@ -2,18 +2,17 @@ package at.asitplus.crypto.datatypes.jws
 
 val JweEncryption.jcaName
     get() = when (this) {
-        JweEncryption.A256GCM -> "AES/GCM/NoPadding"
+        JweEncryption.A128GCM, JweEncryption.A192GCM, JweEncryption.A256GCM -> "AES/GCM/NoPadding"
     }
 
 val JweEncryption.jcaKeySpecName
     get() = when (this) {
-        JweEncryption.A256GCM -> "AES"
+        JweEncryption.A128GCM, JweEncryption.A192GCM, JweEncryption.A256GCM -> "AES"
     }
 
 val JweAlgorithm.jcaName
     get() = when (this) {
         JweAlgorithm.ECDH_ES -> "ECDH"
-        JweAlgorithm.RSA_OAEP_256 -> "RSA-OAEP-256"
-        JweAlgorithm.RSA_OAEP_384 -> "RSA-OAEP-384"
-        JweAlgorithm.RSA_OAEP_512 -> "RSA-OAEP-512"
+        JweAlgorithm.A128KW, JweAlgorithm.A192KW, JweAlgorithm.A256KW -> "AES"
+        JweAlgorithm.RSA_OAEP_256, JweAlgorithm.RSA_OAEP_384, JweAlgorithm.RSA_OAEP_512 -> "RSA/ECB/OAEPPadding"
     }

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JweEncryptedTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JweEncryptedTest.kt
@@ -1,0 +1,39 @@
+package at.asitplus.crypto.datatypes.jws
+
+import com.nimbusds.jose.EncryptionMethod
+import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.JWEHeader
+import com.nimbusds.jose.JWEObject
+import com.nimbusds.jose.Payload
+import com.nimbusds.jose.crypto.AESEncrypter
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import javax.crypto.KeyGenerator
+import kotlin.random.Random
+
+
+class JweEncryptedTest : FreeSpec({
+
+    "Minimal JWE can be parsed and verified" - {
+        val input = Random.Default.nextBytes(32)
+
+        val nimbusHeader = JWEHeader.Builder(
+            JWEAlgorithm.A128KW, EncryptionMethod.A128GCM
+        ).build()
+        val jweNimbus = JWEObject(
+            nimbusHeader,
+            Payload(input)
+        )
+
+        val secretKey = KeyGenerator.getInstance("AES").apply { init(128) }.generateKey()
+        jweNimbus.encrypt(AESEncrypter(secretKey))
+
+        val parsed = JweEncrypted.parse(jweNimbus.serialize()).getOrThrow()
+
+        //val header = parsed.header.shouldNotBeNull()
+        val header = JweHeader.deserialize(parsed.headerAsParsed.decodeToString()).getOrThrow()
+        header.algorithm shouldBe JweAlgorithm.A128KW
+        header.encryption shouldBe JweEncryption.A128GCM
+        parsed.ciphertext shouldBe jweNimbus.cipherText.decode()
+    }
+})

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
@@ -1,19 +1,21 @@
 package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.crypto.datatypes.CryptoPublicKey
+import at.asitplus.crypto.datatypes.EcCurve
 import at.asitplus.crypto.datatypes.fromJcaPublicKey
 import at.asitplus.crypto.datatypes.io.Base64Strict
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import java.security.KeyPairGenerator
 import java.security.interfaces.ECPublicKey
+import kotlin.random.Random
 
 class JwkTest : FreeSpec({
     "EC" - {
-
         withData(256, 384, 521) { bits ->
             val keys = List<ECPublicKey>(10) {
                 val ecKp = KeyPairGenerator.getInstance("EC").apply {
@@ -39,5 +41,42 @@ class JwkTest : FreeSpec({
                 CryptoPublicKey.fromDid(own.keyId!!) shouldBe cryptoPubKey
             }
         }
+    }
+
+    "Serialize and deserialize EC" {
+        val jwk = JsonWebKey(
+            curve = EcCurve.SECP_256_R_1,
+            type = JwkType.EC,
+            x = Random.nextBytes(32),
+            y = Random.nextBytes(32),
+            publicKeyUse = Random.nextBytes(16).encodeToString(Base64Strict),
+            keyOperations = setOf(Random.nextBytes(16).encodeToString(Base64Strict)),
+            certificateUrl = Random.nextBytes(16).encodeToString(Base64Strict),
+            certificateChain = listOf(Random.nextBytes(64)),
+            certificateSha1Thumbprint = Random.nextBytes(20),
+            certificateSha256Thumbprint = Random.nextBytes(32),
+        )
+
+        val parsed = JsonWebKey.deserialize(jwk.serialize()).getOrThrow()
+
+        parsed shouldBe jwk
+    }
+
+    "Serialize and deserialize RSA" {
+        val jwk = JsonWebKey(
+            type = JwkType.RSA,
+            n = Random.nextBytes(64),
+            e = Random.nextBytes(8),
+            publicKeyUse = Random.nextBytes(16).encodeToString(Base64Strict),
+            keyOperations = setOf(Random.nextBytes(16).encodeToString(Base64Strict)),
+            certificateUrl = Random.nextBytes(16).encodeToString(Base64Strict),
+            certificateChain = listOf(Random.nextBytes(64)),
+            certificateSha1Thumbprint = Random.nextBytes(20),
+            certificateSha256Thumbprint = Random.nextBytes(32),
+        )
+
+        val parsed = JsonWebKey.deserialize(jwk.serialize()).getOrThrow()
+
+        parsed shouldBe jwk
     }
 })

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
@@ -8,7 +8,8 @@ import at.asitplus.crypto.datatypes.asn1.Asn1String
 import at.asitplus.crypto.datatypes.asn1.Asn1Time
 import at.asitplus.crypto.datatypes.fromJcaPublicKey
 import at.asitplus.crypto.datatypes.io.Base64Strict
-import at.asitplus.crypto.datatypes.pki.DistinguishedName
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue
+import at.asitplus.crypto.datatypes.pki.RelativeDistinguishedName
 import at.asitplus.crypto.datatypes.pki.TbsCertificate
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.kotest.core.spec.style.FreeSpec
@@ -91,11 +92,11 @@ class JwkTest : FreeSpec({
 private fun randomCertificate() = X509Certificate(
     TbsCertificate(
         serialNumber = Random.nextBytes(16),
-        issuerName = listOf(DistinguishedName.CommonName(Asn1String.Printable("Test"))),
+        issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.Printable("Test")))),
         publicKey = CryptoPublicKey.Ec.fromJcaPublicKey(KeyPairGenerator.getInstance("EC").apply { initialize(256) }
             .genKeyPair().public as ECPublicKey).getOrThrow(),
         signatureAlgorithm = CryptoAlgorithm.ES256,
-        subjectName = listOf(DistinguishedName.CommonName(Asn1String.Printable("Test"))),
+        subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.Printable("Test")))),
         validFrom = Asn1Time(Clock.System.now()),
         validUntil = Asn1Time(Clock.System.now()),
     ),

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwsSignedTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwsSignedTest.kt
@@ -2,7 +2,6 @@ package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.getJcaPublicKey
-import at.asitplus.crypto.datatypes.jws.JwsSigned
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.crypto.ECDSAVerifier
 import com.nimbusds.jose.crypto.RSASSAVerifier
@@ -19,11 +18,9 @@ class JwsSignedTest : FreeSpec({
             ?: throw Exception("TestVectors not found")
 
         withData(testvec) { input ->
-            val parsed = JwsSigned.parse(input)
-            parsed.shouldNotBeNull()
+            val parsed = JwsSigned.parse(input).getOrThrow()
 
-            val publicKey = parsed.header.publicKey
-            publicKey.shouldNotBeNull()
+            val publicKey = parsed.header.publicKey.shouldNotBeNull()
 
             val jvmVerifier =
                 if (publicKey is CryptoPublicKey.Ec) ECDSAVerifier(publicKey.getJcaPublicKey().getOrThrow())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
@@ -4,7 +4,7 @@ import at.asitplus.crypto.datatypes.asn1.*
 import at.asitplus.crypto.datatypes.asn1.BERTags.BIT_STRING
 import at.asitplus.crypto.datatypes.asn1.BERTags.INTEGER
 import at.asitplus.crypto.datatypes.asn1.DERTags.DER_SEQUENCE
-import at.asitplus.crypto.datatypes.io.Base64UrlStrict
+import at.asitplus.crypto.datatypes.io.Base64Strict
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.Contextual
@@ -59,11 +59,11 @@ sealed class CryptoSignature(
             get() = PrimitiveSerialDescriptor("CryptoSignature", PrimitiveKind.STRING)
 
         override fun deserialize(decoder: Decoder): CryptoSignature {
-            return CryptoSignature.decodeFromDer(decoder.decodeString().decodeToByteArray(Base64UrlStrict))
+            return CryptoSignature.decodeFromDer(decoder.decodeString().decodeToByteArray(Base64Strict))
         }
 
         override fun serialize(encoder: Encoder, value: CryptoSignature) {
-            encoder.encodeString(value.encodeToDer().encodeToString(Base64UrlStrict))
+            encoder.encodeString(value.encodeToDer().encodeToString(Base64Strict))
         }
     }
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
@@ -210,6 +210,7 @@ class Asn1Sequence internal constructor(children: List<Asn1Element>) : Asn1Struc
  * ASN.1 OCTET STRING 0x04 ([BERTags.OCTET_STRING]) containing an [Asn1Element]
  * @param children the elements to put into this sequence
  */
+@Serializable(with = Asn1EncodableSerializer::class)
 class Asn1EncapsulatingOctetString(children: List<Asn1Element>) : Asn1Structure(BERTags.OCTET_STRING, children),
     Asn1OctetString<Asn1EncapsulatingOctetString> {
     override val content: ByteArray by lazy {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
@@ -59,6 +59,9 @@ class Asn1Time(val instant: Instant, formatOverride: Format? = null) : Asn1Encod
         return result
     }
 
+    override fun toString(): String {
+        return "Asn1Time(instant=$instant, format=$format)"
+    }
 
     /**
      * Enum of supported Time formats

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
@@ -15,17 +15,14 @@ import kotlinx.serialization.encoding.Encoder
  * @param formatOverride to force either  GENERALIZED TIME or UTC TIME
  */
 @Serializable(with = CertTimeStampSerializer::class)
-class Asn1Time(val instant: Instant, formatOverride: Format? = null) : Asn1Encodable<Asn1Primitive> {
+class Asn1Time(instant: Instant, formatOverride: Format? = null) : Asn1Encodable<Asn1Primitive> {
+
+    val instant = Instant.fromEpochSeconds(instant.epochSeconds)
 
     /**
      * Indicates whether this timestamp uses UTC TIME or GENERALIZED TIME
      */
-    val format: Format
-
-    init {
-        format =
-            formatOverride ?: if (instant > THRESHOLD_GENERALIZED_TIME) Format.GENERALIZED else Format.UTC
-    }
+    val format: Format =  formatOverride ?: if (this.instant > THRESHOLD_GENERALIZED_TIME) Format.GENERALIZED else Format.UTC
 
     companion object : Asn1Decodable<Asn1Primitive, Asn1Time> {
         private val THRESHOLD_GENERALIZED_TIME = Instant.parse("2050-01-01T00:00:00Z")

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
@@ -92,7 +92,6 @@ private constructor(private val extensions: List<Asn1Element>) {
         }.map { (it as Asn1Primitive).content.decodeToString() }
 
     override fun toString(): String {
-        //StringBuilder()
         val bld =
             StringBuilder("\notherNames=").append(otherNames.joinToString { it.prettyPrint() })
         bld.append("\nrfc822Names=").append(rfc822Names?.joinToString())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
@@ -1,0 +1,144 @@
+package at.asitplus.crypto.datatypes.pki
+
+import at.asitplus.crypto.datatypes.asn1.*
+import at.asitplus.crypto.datatypes.asn1.DERTags.toImplicitTag
+import at.asitplus.crypto.datatypes.pki.AlternativeNames.Companion.findIssuerAltNames
+import at.asitplus.crypto.datatypes.pki.AlternativeNames.Companion.findSubjectAltNames
+
+
+/**
+ * [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) {Subject||Issuer}AlternativeNames (SANs, IANs)
+ * container class constructed from a certificate's [extensions] (i.e. [TbsCertificate.extensions] filtered by OID).
+ * Hence, this class is not intended to be used for constructing SANs or IANs, but used to extract them from a certificate.
+ *
+ * As this class performs some structural validations upon initialisation, it may throw various kinds of [Throwable]s.
+ * These are **not** limited to [Asn1Exception]s, which is why constructor invocation should be wrapped inside
+ * a [runRethrowing] block, as done in [findSubjectAltNames] and [findIssuerAltNames].
+ *
+ * See [RFC 5280, Section 4.2.1.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6)
+ * for details on the properties of this container class, as they are named accordingly.
+ */
+data class AlternativeNames
+@Throws(Throwable::class)
+private constructor(private val extensions: List<Asn1Element>) {
+
+    val dnsNames: List<String>? = parseStringSANs(SubjectAltNameImplicitTags.dNSName)
+    val rfc822Names: List<String>? = parseStringSANs(SubjectAltNameImplicitTags.rfc822Name)
+    val uris: List<String>? = parseStringSANs(SubjectAltNameImplicitTags.uniformResourceIdentifier)
+
+    val ipAddresses: List<ByteArray> = extensions.filter { it.tag == SubjectAltNameImplicitTags.iPAddress }.apply {
+        forEach {
+            if (it !is Asn1Primitive)
+                throw Asn1StructuralException("Invalid iPAddress Alternative Name found: ${it.toDerHexString()}")
+            else if (it.content.size != 4 && it.content.size != 16) throw Asn1StructuralException("Invalid iPAddress Alternative Name found: ${it.toDerHexString()}")
+        }
+    }.map { (it as Asn1Primitive).content }
+
+    val directoryNames: List<List<DistinguishedName>> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.directoryName }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid directoryName Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map { (it as Asn1Sequence).children.map { DistinguishedName.decodeFromTlv(it as Asn1Set) } }
+
+    val otherNames: List<Asn1Sequence> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.otherName }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid otherName Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map {
+            (it as Asn1Sequence).also {
+                if (it.children.size != 2) throw Asn1StructuralException("Invalid otherName Alternative Name found (!=2 children): ${it.toDerHexString()}")
+                if (it.children.last().tag != 0u.toImplicitTag()) throw Asn1StructuralException("Invalid otherName Alternative Name found (implicit tag != 0): ${it.toDerHexString()}")
+                ObjectIdentifier.parse((it.children.first() as Asn1Primitive).content) //this throws if something is off
+            }
+        }
+    val ediPartyNames: List<Asn1Sequence> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.ediPartyName }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid ediPartyName Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map {
+            (it as Asn1Sequence).also {
+                if (it.children.size > 2) throw Asn1StructuralException("Invalid partyName Alternative Name found (>2 children): ${it.toDerHexString()}")
+                if (it.children.find { it.tag != 0u.toImplicitTag() && it.tag != 1u.toImplicitTag() } != null) throw Asn1StructuralException(
+                    "Invalid partyName Alternative Name found (illegal implicit tag): ${it.toDerHexString()}"
+                )
+                //TODO: strict string parsing
+            }
+        }
+
+    val x400Addresses: List<Asn1Sequence> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.x400Address }.apply {
+            forEach {
+                if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid x400Address Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map {
+            (it as Asn1Sequence).also {
+                //TODO: strict structural parsing
+            }
+        }
+
+    val registeredIDs: List<ObjectIdentifier> =
+        extensions.filter { it.tag == SubjectAltNameImplicitTags.registeredID }.apply {
+            forEach {
+                if (it !is Asn1Primitive) throw Asn1StructuralException("Invalid registeredID Alternative Name found: ${it.toDerHexString()}")
+            }
+        }.map { ObjectIdentifier.parse((it as Asn1Primitive).content) }
+
+    private fun parseStringSANs(implicitTag: UByte) =
+        extensions.filter { it.tag == implicitTag }.apply {
+            forEach { if (it !is Asn1Primitive) throw Asn1StructuralException("Invalid dnsName Alternative Name found: ${it.toDerHexString()}") }
+        }.map { (it as Asn1Primitive).content.decodeToString() }
+
+    override fun toString(): String {
+        //StringBuilder()
+        val bld =
+            StringBuilder("\notherNames=").append(otherNames.joinToString { it.prettyPrint() })
+        bld.append("\nrfc822Names=").append(rfc822Names?.joinToString())
+        bld.append("\ndnsNames=").append(dnsNames?.joinToString())
+        bld.append("\nx400addresses=").append(x400Addresses.joinToString { it.prettyPrint() })
+        bld.append("\ndirectoryNames=").append(directoryNames.joinToString())
+        bld.append("\nediPartyNames=").append(ediPartyNames.joinToString { it.prettyPrint() })
+        bld.append("\nuris=").append(uris?.joinToString())
+        @OptIn(ExperimentalStdlibApi::class)
+        bld.append("\nipAddresses=").append(ipAddresses.joinToString { it.toHexString(HexFormat.UpperCase) })
+        bld.append("\nregisteredIDs=").append(registeredIDs.joinToString())
+        return "AlternativeNames(" + bld.toString().prependIndent("  ") + "\n)"
+    }
+
+    companion object {
+        @Throws(Asn1Exception::class)
+        fun List<X509CertificateExtension>.findSubjectAltNames() = runRethrowing {
+            find(KnownOIDs.subjectAltName_2_5_29_17)?.let { AlternativeNames(it) }
+        }
+
+        @Throws(Asn1Exception::class)
+        fun List<X509CertificateExtension>.findIssuerAltNames() = runRethrowing {
+            find(KnownOIDs.issuerAltName_2_5_29_18)?.let { AlternativeNames(it) }
+        }
+
+        /**not for public use, since it forces [Asn1EncapsulatingOctetString]*/
+        private fun List<X509CertificateExtension>.find(oid: ObjectIdentifier): List<Asn1Element>? {
+            val matches = filter { it.oid == oid }
+            if (matches.size > 1) throw Asn1StructuralException("More than one extension with oid $oid found")
+            return if (matches.isEmpty()) null
+            else ((matches.first().value as Asn1EncapsulatingOctetString).children?.firstOrNull() as Asn1Sequence?)?.children
+        }
+    }
+}
+
+/**
+ * Enumeration of implicit tags used to indicate different `SubjectAltName`s
+ */
+object SubjectAltNameImplicitTags {
+    val otherName = 0u.toImplicitTag()
+    val rfc822Name = 1u.toImplicitTag()
+    val dNSName = 2u.toImplicitTag()
+    val x400Address = 3u.toImplicitTag()
+    val directoryName = 4u.toImplicitTag()
+    val ediPartyName = 5u.toImplicitTag()
+    val uniformResourceIdentifier = 6u.toImplicitTag()
+    val iPAddress = 7u.toImplicitTag()
+    val registeredID = 8u.toImplicitTag()
+}

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/AlternativeNames.kt
@@ -34,12 +34,12 @@ private constructor(private val extensions: List<Asn1Element>) {
         }
     }.map { (it as Asn1Primitive).content }
 
-    val directoryNames: List<List<DistinguishedName>> =
+    val directoryNames: List<List<RelativeDistinguishedName>> =
         extensions.filter { it.tag == SubjectAltNameImplicitTags.directoryName }.apply {
             forEach {
                 if (it !is Asn1Sequence) throw Asn1StructuralException("Invalid directoryName Alternative Name found: ${it.toDerHexString()}")
             }
-        }.map { (it as Asn1Sequence).children.map { DistinguishedName.decodeFromTlv(it as Asn1Set) } }
+        }.map { (it as Asn1Sequence).children.map { RelativeDistinguishedName.decodeFromTlv(it as Asn1Set) } }
 
     val otherNames: List<Asn1Sequence> =
         extensions.filter { it.tag == SubjectAltNameImplicitTags.otherName }.apply {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/Pkcs10CertificationRequest.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TbsCertificationRequest(
     val version: Int = 0,
-    val subjectName: List<DistinguishedName>,
+    val subjectName: List<RelativeDistinguishedName>,
     val publicKey: CryptoPublicKey,
     val attributes: List<Pkcs10CertificationRequestAttribute>? = null
 ) : Asn1Encodable<Asn1Sequence> {
@@ -42,7 +42,7 @@ data class TbsCertificationRequest(
      */
     @Throws(IllegalArgumentException::class)
     constructor(
-        subjectName: List<DistinguishedName>,
+        subjectName: List<RelativeDistinguishedName>,
         publicKey: CryptoPublicKey,
         extensions: List<X509CertificateExtension>,
         version: Int = 0,
@@ -91,7 +91,7 @@ data class TbsCertificationRequest(
         override fun decodeFromTlv(src: Asn1Sequence) = runRethrowing {
             val version = (src.nextChild() as Asn1Primitive).readInt()
             val subject = (src.nextChild() as Asn1Sequence).children.map {
-                DistinguishedName.decodeFromTlv(it as Asn1Set)
+                RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)
             }
             val cryptoPublicKey = CryptoPublicKey.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val attributes = if (src.hasMoreChildren()) {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
@@ -25,10 +25,10 @@ constructor(
     val version: Int = 2,
     @Serializable(with = ByteArrayBase64Serializer::class) val serialNumber: ByteArray,
     val signatureAlgorithm: CryptoAlgorithm,
-    val issuerName: List<DistinguishedName>,
+    val issuerName: List<RelativeDistinguishedName>,
     val validFrom: Asn1Time,
     val validUntil: Asn1Time,
-    val subjectName: List<DistinguishedName>,
+    val subjectName: List<RelativeDistinguishedName>,
     val publicKey: CryptoPublicKey,
     val issuerUniqueID: BitSet? = null,
     val subjectUniqueID: BitSet? = null,
@@ -153,12 +153,12 @@ constructor(
             val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
             val sigAlg = CryptoAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val issuerNames = (src.nextChild() as Asn1Sequence).children.map {
-                DistinguishedName.decodeFromTlv(it as Asn1Set)
+                RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)
             }
 
             val timestamps = decodeTimestamps(src.nextChild() as Asn1Sequence)
             val subject = (src.nextChild() as Asn1Sequence).children.map {
-                DistinguishedName.decodeFromTlv(it as Asn1Set)
+                RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)
             }
 
             val cryptoPublicKey = CryptoPublicKey.decodeFromTlv(src.nextChild() as Asn1Sequence)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
@@ -253,7 +253,7 @@ data class X509Certificate(
         override fun decodeFromTlv(src: Asn1Sequence): X509Certificate = runRethrowing {
             val tbs = TbsCertificate.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val sigAlg = CryptoAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
-            val signature = CryptoSignature.decodeFromTlv(src.nextChild())
+            val signature = if(sigAlg.isEc) CryptoSignature.EC.decodeFromTlvBitString(src.nextChild() as Asn1Primitive) else CryptoSignature.RSAorHMAC.decodeFromTlvBitString(src.nextChild() as Asn1Primitive)
             if (src.hasMoreChildren()) throw Asn1StructuralException("Superfluous structure in Certificate Structure")
             return X509Certificate(tbs, sigAlg, signature)
         }

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/DistinguishedNameTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/DistinguishedNameTest.kt
@@ -1,11 +1,11 @@
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.KnownOIDs
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.CommonName
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.Country
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.Organization
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.OrganizationalUnit
-import at.asitplus.crypto.datatypes.pki.DistinguishedName.Other
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.CommonName
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Country
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Organization
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.OrganizationalUnit
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Other
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Pkcs10CertificationRequestJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Pkcs10CertificationRequestJvmTest.kt
@@ -10,11 +10,7 @@ import at.asitplus.crypto.datatypes.asn1.ObjectIdentifier
 import at.asitplus.crypto.datatypes.asn1.encodeToTlv
 import at.asitplus.crypto.datatypes.asn1.ensureSize
 import at.asitplus.crypto.datatypes.asn1.parse
-import at.asitplus.crypto.datatypes.pki.DistinguishedName
-import at.asitplus.crypto.datatypes.pki.Pkcs10CertificationRequest
-import at.asitplus.crypto.datatypes.pki.Pkcs10CertificationRequestAttribute
-import at.asitplus.crypto.datatypes.pki.TbsCertificationRequest
-import at.asitplus.crypto.datatypes.pki.X509CertificateExtension
+import at.asitplus.crypto.datatypes.pki.*
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -68,7 +64,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
 
         val tbsCsr = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf( RelativeDistinguishedName(listOf(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName))))),
             publicKey = cryptoPublicKey
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
@@ -109,7 +105,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
             .build(contentSigner)
         val tbsCsr = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName( listOf(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName))))),
             publicKey = cryptoPublicKey,
             attributes = listOf(
                 Pkcs10CertificationRequestAttribute(KnownOIDs.keyUsage, Asn1Element.parse(keyUsage.encoded)),
@@ -157,7 +153,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
             .addAttribute(ASN1ObjectIdentifier("1.2.1840.13549.1.9.16.1337.26"), ASN1Integer(1337L))
             .build(contentSigner)
         val tbsCsr = TbsCertificationRequest(
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey,
             extensions = listOf(
                 X509CertificateExtension(
@@ -212,7 +208,7 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
         //x509Certificate.encodeToDer() shouldBe certificateHolder.encoded
         csr.signatureAlgorithm shouldBe signatureAlgorithm
         csr.tbsCsr.version shouldBe 0
-        (csr.tbsCsr.subjectName.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
+        (csr.tbsCsr.subjectName.first().attrsAndValues.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
         val parsedPublicKey = csr.tbsCsr.publicKey
         parsedPublicKey.shouldBeInstanceOf<CryptoPublicKey.Ec>()
         parsedPublicKey.x shouldBe keyX
@@ -236,37 +232,37 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
 
         val tbsCsr1 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey1
         )
         val tbsCsr11 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey1
         )
         val tbsCsr111 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName1))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName1)))),
             publicKey = cryptoPublicKey1
         )
         val tbsCsr12 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey11
         )
         val tbsCsr122 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName1))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName1)))),
             publicKey = cryptoPublicKey11
         )
         val tbsCsr2 = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey2
         )
         val tbsCsr22 = TbsCertificationRequest(
             version = 1,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey2
         )
 

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
@@ -1,8 +1,6 @@
 package at.asitplus.crypto.datatypes
 
-import at.asitplus.crypto.datatypes.asn1.Asn1Element
-import at.asitplus.crypto.datatypes.asn1.Asn1Sequence
-import at.asitplus.crypto.datatypes.asn1.parse
+import at.asitplus.crypto.datatypes.asn1.*
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
@@ -52,6 +50,8 @@ class X509CertParserTest : FreeSpec({
                         "Actual: ${cert.encodeToDer().encodeToString(Base16)}"
             ) {
                 cert.encodeToTlv().derEncoded shouldBe jcaCert.encoded
+
+                cert shouldBe X509Certificate.decodeFromByteArray(certBytes)
             }
         }
     }
@@ -87,6 +87,7 @@ class X509CertParserTest : FreeSpec({
                 "Expect: ${crt.encoded.encodeToString(Base16)}\n" + "Actual: ${own.encodeToString(Base16)}"
             ) {
                 own shouldBe crt.encoded
+                own shouldBe X509Certificate.decodeFromByteArray(crt.encoded)
             }
         }
     }
@@ -101,7 +102,8 @@ class X509CertParserTest : FreeSpec({
 
             withData(nameFn = { it.first }, good) {
                 val src = Asn1Element.parse(it.second) as Asn1Sequence
-                X509Certificate.decodeFromTlv(src)
+                val decoded = X509Certificate.decodeFromTlv(src)
+                decoded shouldBe X509Certificate.decodeFromByteArray(it.second)
             }
         }
         "Faulty certs should glitch out" - {

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
@@ -1,10 +1,7 @@
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.*
-import at.asitplus.crypto.datatypes.pki.DistinguishedName
-import at.asitplus.crypto.datatypes.pki.TbsCertificate
-import at.asitplus.crypto.datatypes.pki.X509Certificate
-import at.asitplus.crypto.datatypes.pki.X509CertificateExtension
+import at.asitplus.crypto.datatypes.pki.*
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -74,11 +71,11 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = Asn1Time(notBeforeDate.toInstant().toKotlinInstant()),
             validUntil = Asn1Time(notAfterDate.toInstant().toKotlinInstant()),
             signatureAlgorithm = signatureAlgorithm,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
@@ -120,11 +117,11 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = Asn1Time(notBeforeDate.toInstant().toKotlinInstant()),
             validUntil = Asn1Time(notAfterDate.toInstant().toKotlinInstant()),
             signatureAlgorithm = signatureAlgorithm,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
@@ -167,8 +164,8 @@ class X509CertificateJvmTest : FreeSpec({
         //x509Certificate.encodeToDer() shouldBe certificateHolder.encoded
         x509Certificate.signatureAlgorithm shouldBe signatureAlgorithm
         x509Certificate.tbsCertificate.version shouldBe 2
-        (x509Certificate.tbsCertificate.issuerName.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
-        (x509Certificate.tbsCertificate.subjectName.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
+        (x509Certificate.tbsCertificate.issuerName.first().attrsAndValues.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
+        (x509Certificate.tbsCertificate.subjectName.first().attrsAndValues.first().value as Asn1Primitive).content shouldBe commonName.encodeToByteArray()
         x509Certificate.tbsCertificate.serialNumber shouldBe serialNumber.toByteArray()
         x509Certificate.tbsCertificate.signatureAlgorithm shouldBe signatureAlgorithm
         x509Certificate.tbsCertificate.validFrom.instant shouldBe notBeforeDate.toInstant()
@@ -273,53 +270,53 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate1 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate2 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate3 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm512,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate4 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8("DefaultCryptoService1"))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8("DefaultCryptoService1")))),
             publicKey = cryptoPublicKey
         )
         val tbsCertificate5 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = Asn1Time(Date.from(Instant.now().plusSeconds(1)).toInstant().toKotlinInstant()),
             validUntil = Asn1Time(
                 Date.from(Instant.now().plusSeconds(30.days.inWholeSeconds)).toInstant().toKotlinInstant()
             ),
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
 
@@ -420,11 +417,11 @@ class X509CertificateJvmTest : FreeSpec({
         val tbsCertificate6 = TbsCertificate(
             version = 2,
             serialNumber = serialNumber.toByteArray(),
-            issuerName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            issuerName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             validFrom = validFromDate,
             validUntil = validUntilDate,
             signatureAlgorithm = signatureAlgorithm256,
-            subjectName = listOf(DistinguishedName.CommonName(Asn1String.UTF8(commonName))),
+            subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey,
             extensions = listOf(ext1)
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion = 3.0.0-SNAPSHOT
+artifactVersion = 3.0.0
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion = 2.6.0
+artifactVersion = 2.7.0-SNAPSHOT
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion = 2.7.0-SNAPSHOT
+artifactVersion = 3.0.0-SNAPSHOT
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
 


### PR DESCRIPTION
**Fixes**
 * Restructure and fix `RelativeDistinguishedName`. **THIS IS A BREAKING CHANGE**
 * Fix `Asn1Time` not truncating to seconds
 * Fix parsing of CryptoSignature when decoding Certificates
 * Remove bogus `serialize()` function from `CryptoSignature`  **THIS IS A BREAKING CHANGE**


**Features**
 * Wrap exceptions during deserialization in `KmmResult`, i.e. changing all `deserialize()` methods in companion objects  **THIS IS A BREAKING CHANGE**
 * Move class `JweDecrypted` from package `at.asitplus.wallet.lib.jws` to `at.asitplus.crypto.datatypes.jws`  **THIS IS A BREAKING CHANGE**
 * Support more JWE algorithms, e.g. AES
 * Add `header` to constructor parameters of `JweEncrypted`
 * Extend properties of `JsonWebKey`
 * Introduce `CertificateChain` typealias with `.leaf` and `.root` convenience properties
 * Use `CertificateChain` inside `JwsHeader` instead of `Array<ByteArray>'
 * Use `CertificateChain` inside `JsonWebKey` instead of `Array<ByteArray>'

 * SubjectAltNames and IssuerAltNames:
    * Perform some structural validations on SAN and IAN
    * Expose `TbsCertificate.issuerAltNames` and `TbsCertificte.subjectAltnames`, which contain (somewhat) parsed
      `AlternativeNames` structures for easy access to `dnsName`. `iPAddress`, etc.
