### PR TITLE
CryptoSignature rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 
 **Fixes**
  * Standardize class names: `Ec` -> `EC` everywhere
+ * Fix an edge case where very small `r`/`s` in `CryptoSignature.EC` would be corrupted
 
 **Features**
  * Support ASN.1 encoding/decoding for `BigInteger`
@@ -123,3 +124,5 @@
  * Extend list of values in `JweAlgorithm` and `JweEncryption`
  * Extend properties in `JweHeader`
  * Extend properties in `JwsHeader`
+ * Expose `r` and `s` of `CryptoSignature.EC`
+

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECCurve.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECCurve.kt
@@ -51,6 +51,7 @@ enum class ECCurve(
     inline val signatureLengthBytes: UInt get() = scalarLength.bytes*2u
 
     internal val coordinateCreator by lazy { ModularBigInteger.creatorForModulo(this.modulus) }
+    internal val scalarCreator by lazy { ModularBigInteger.creatorForModulo(this.order) }
     
     /**
      * p: Prime modulus of the underlying prime field

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
@@ -631,9 +631,9 @@ fun ByteArray.padWithZeroIfNeeded() =
 /**
  * Drops or adds zero bytes at the start until the [size] is reached
  */
-//TODO: This performs horribly!
-fun ByteArray.ensureSize(size: UInt): ByteArray = when {
-    this.size.toUInt() > size -> this.drop(1).toByteArray().ensureSize(size)
-    this.size.toUInt() < size -> (byteArrayOf(0) + this).ensureSize(size)
+fun ByteArray.ensureSize(size: Int): ByteArray = (this.size-size).let { toDrop -> when {
+    toDrop > 0 -> this.copyOfRange(toDrop, this.size)
+    toDrop < 0 -> ByteArray(-toDrop) + this
     else -> this
-}
+} }
+inline fun ByteArray.ensureSize(size: UInt) = ensureSize(size.toInt())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
@@ -611,24 +611,6 @@ fun Int.encodeToByteArray(): ByteArray {
 }
 
 /**
- * Strips the leading 0x00 byte of an ASN.1-encoded Integer,
- * that will be there if the first bit of the value is set,
- * i.e. it is over 0x7F (or < 0 if it is signed)
- */
-fun ByteArray.stripLeadingSignByte() =
-    if (this[0] == 0.toByte() && this[1] < 0) drop(1).toByteArray() else this
-
-/**
- * Adds a leading 0x00 byte for ASN.1 encoding of unsigned Integers,
- * i.e. when the first byte is over 0x7F
- */
-fun ByteArray.padWithZeroIfNeeded() =
-    if (this.isNotEmpty() && this[0].toUByte() >= 0x80.toUByte())
-        byteArrayOf(0x00) + this
-    else
-        this
-
-/**
  * Drops or adds zero bytes at the start until the [size] is reached
  */
 fun ByteArray.ensureSize(size: Int): ByteArray = (this.size-size).let { toDrop -> when {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/BitLength.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/BitLength.kt
@@ -4,11 +4,21 @@ import com.ionspin.kotlin.bignum.integer.BigInteger
 import kotlin.jvm.JvmInline
 
 @JvmInline
-value class BitLength (val bits: UInt) {
+value class BitLength (val bits: UInt): Comparable<BitLength> {
     inline val bytes: UInt get() =
         bits.floorDiv(8u) + (if(bits.rem(8u) != 0u) 1u else 0u)
 
     companion object {
         inline fun of(v: BigInteger) = BitLength(v.bitLength().toUInt())
     }
+
+    inline override fun compareTo(other: BitLength): Int =
+        bits.compareTo(other.bits)
+
 }
+
+inline fun min(a: BitLength, b: BitLength) =
+    if (a.bits < b.bits) a else b
+
+inline fun max(a: BitLength, b: BitLength) =
+    if (a.bits < b.bits) b else a

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/CryptoSignatureTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/CryptoSignatureTest.kt
@@ -1,9 +1,14 @@
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
+import at.asitplus.crypto.datatypes.asn1.ensureSize
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.toBigInteger
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
 
 class CryptoSignatureTest : FreeSpec({
 
@@ -14,9 +19,9 @@ class CryptoSignatureTest : FreeSpec({
             val first: Int = values.random().also { values.remove(it) }
             val second: Int = values.random().also { values.remove(it) }
 
-            val ec1 = CryptoSignature.EC(first.encodeToByteArray(), second.encodeToByteArray())
-            val ec2 = CryptoSignature.EC(first.encodeToByteArray(), second.encodeToByteArray())
-            val ec3 = CryptoSignature.EC(second.encodeToByteArray(), first.encodeToByteArray())
+            val ec1 = CryptoSignature.EC.fromRS(first.toBigInteger(), second.toBigInteger())
+            val ec2 = CryptoSignature.EC.fromRS(first.toBigInteger(), second.toBigInteger())
+            val ec3 = CryptoSignature.EC.fromRS(second.toBigInteger(), first.toBigInteger())
             val rsa1 = CryptoSignature.RSAorHMAC(first.encodeToByteArray())
             val rsa2 = CryptoSignature.RSAorHMAC(first.encodeToByteArray())
             val rsa3 = CryptoSignature.RSAorHMAC(second.encodeToByteArray())
@@ -36,6 +41,50 @@ class CryptoSignatureTest : FreeSpec({
             rsa1.hashCode() shouldBe rsa1.hashCode()
             rsa1.hashCode() shouldBe rsa2.hashCode()
             rsa1.hashCode() shouldNotBe rsa3.hashCode()
+
+            val ec4 = ec3.guessCurve()
+            ec4.scalarByteLength shouldBe ECCurve.values().minOf { it.scalarLength.bytes }
+            ec4 shouldBe ec4
+            ec4 shouldNotBe ec3
+            ec4.hashCode() shouldBe ec4.hashCode()
+            ec4.hashCode() shouldNotBe ec3.hashCode()
         }
+    }
+
+    "Length handling & Curve guessing" {
+        val r = BigInteger.ONE.shl(ECCurve.SECP_521_R_1.scalarLength.bits.toInt()-1)
+        val s = BigInteger.ONE
+        val encoded =
+            ByteArray(66) { if (it == 0) 0x01 else 0x00 } +
+            ByteArray(66) { if (it == 65) 0x01 else 0x00 }
+
+        val sig = CryptoSignature.EC.fromRS(r, s)
+        shouldThrow<IllegalStateException> { sig.rawByteArray }
+
+        val sig1 = sig.guessCurve()
+        sig1 shouldNotBe sig
+        sig1.r shouldBe sig.r
+        sig1.s shouldBe sig.s
+        sig1.scalarByteLength shouldBe ECCurve.SECP_521_R_1.scalarLength.bytes
+        sig1.rawByteArray shouldBe encoded
+
+        val sig2 = sig.withCurve(ECCurve.SECP_521_R_1)
+        sig2 shouldBe sig1
+        sig2 shouldNotBe sig
+        sig2.r shouldBe sig.r
+        sig2.s shouldBe sig.s
+        sig2.scalarByteLength shouldBe sig1.scalarByteLength
+        sig2.rawByteArray shouldBe encoded
+
+        val sig3 = CryptoSignature.EC.fromRawBytes(encoded)
+        sig3 shouldBe sig2
+        sig3 shouldNotBe sig
+        sig3.r shouldBe sig.r
+        sig3.s shouldBe sig.s
+        sig3.scalarByteLength shouldBe sig1.scalarByteLength
+        sig3.rawByteArray shouldBe encoded
+
+        val r2 = BigInteger.ONE.shl(ECCurve.values().maxOf { it.scalarLength.bits }.toInt()+1)
+        shouldThrow<IllegalArgumentException> { CryptoSignature.EC.fromRS(r2, s).guessCurve() }
     }
 })

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/UtilTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/UtilTest.kt
@@ -1,0 +1,38 @@
+package at.asitplus.crypto.datatypes
+
+import at.asitplus.crypto.datatypes.asn1.ensureSize
+import at.asitplus.crypto.datatypes.misc.BitLength
+import at.asitplus.crypto.datatypes.misc.max
+import at.asitplus.crypto.datatypes.misc.min
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class UtilTest : FreeSpec({
+    "ByteArray.ensureSize" {
+        val base = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05)
+
+        base.ensureSize(5) shouldBe base
+        base.ensureSize(3) shouldBe byteArrayOf(0x03, 0x04, 0x05)
+        base.ensureSize(7) shouldBe byteArrayOf(0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05)
+    }
+    "BitLength" {
+        val three = BitLength(3u)
+        val four = BitLength(4u)
+        val fourAgain = BitLength(4u)
+
+        (four == fourAgain) shouldBe true
+        (three < four) shouldBe true
+        (four < three) shouldBe false
+
+        BitLength.of(BigInteger.TEN) shouldBe four
+        max(three, four) shouldBe fourAgain
+        max(four, three) shouldBe fourAgain
+        min(three, four) shouldBe three
+
+        three.bytes shouldBe 1u
+        four.bytes shouldBe 1u
+        BitLength(8u).bytes shouldBe 1u
+        BitLength(9u).bytes shouldBe 2u
+    }
+})

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
@@ -56,7 +56,7 @@ class X509CertParserTest : FreeSpec({
         }
     }
 
-    "system trust store" - {
+    "system trust store".config(enabled = "windows" !in System.getProperty("os.name").lowercase()) {
         val certs = File("/etc/ssl/certs").listFiles { f: File -> f.name.endsWith(".pem") }.mapNotNull {
             runCatching { convertStringToX509Cert(FileReader(it).readText()) }.getOrNull()
         }


### PR DESCRIPTION
* Store `CryptoSignature` as a pair of integers, instead of byte arrays.
* Disallow raw encoding unless the underlying curve's scalar byte length is known.
* Require explicit opt-in (`guessCurve`) before guessing byte length of the underlying curve.
  * Or allow the curve to be specified from context (`withScalarByteLength`, `withCurve`)