### PR TITLE
Small set of Integration Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
  * Standardize class names: `Ec` -> `EC` everywhere
  * Fix an edge case where very small `r`/`s` in `CryptoSignature.EC` would be corrupted
  * Remove bogus ASN.1 encoding from JWS Algorithms
+   * `CryptoSignature.EC` now requires specification of a curve or size when reading raw bytes
 
 **Features**
  * Support ASN.1 encoding/decoding for `BigInteger`
@@ -132,3 +133,6 @@
  * JsonWebKey Changes:
    * do not generate kid when there is none and allow removing it
    * reference `JsonWebAlgorithm` instead of `JwsAlgorithm`
+   * add `.didEncoded`, which may return null, if encoding fails
+ * add `.curve` to EC CryptoAlgorithms
+ * Change JweAlgorithm to sealed class to support unknown algorithms

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -36,8 +36,8 @@ data class JsonWebKey(
      * The "kty" (key type) parameter identifies the cryptographic algorithm
      * family used with the key, such as "RSA" or "EC".  "kty" values should
      * either be registered in the IANA "JSON Web Key Types" registry
-     * established by (JWA) or be a value that contains a Collision-
-     * Resistant Name.  The "kty" value is a case-sensitive string.  This
+     * established by (JWA) or be a value that contains a Collision-Resistant
+     * Name.  The "kty" value is a case-sensitive string.  This
      * member MUST be present in a JWK.
      */
     @SerialName("kty")
@@ -191,6 +191,8 @@ data class JsonWebKey(
 
     fun serialize() = jsonSerializer.encodeToString(this)
 
+    val didEncoded: String? by lazy { toCryptoPublicKey().getOrNull()?.didEncoded }
+
     override fun toString(): String {
         return "JsonWebKey(curve=$curve," +
                 " type=$type," +
@@ -309,7 +311,7 @@ data class JsonWebKey(
             runCatching { jsonSerializer.decodeFromString<JsonWebKey>(it) }.wrap()
 
         fun fromDid(input: String): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.fromDid(input).also { it.jwkId=input }.toJsonWebKey() }.wrap()
+            runCatching { CryptoPublicKey.fromDid(input).also { it.jwkId = input }.toJsonWebKey() }.wrap()
 
         fun fromIosEncoded(bytes: ByteArray): KmmResult<JsonWebKey> =
             runCatching { CryptoPublicKey.fromIosEncoded(bytes).toJsonWebKey() }.wrap()

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -61,7 +61,7 @@ data class JwsSigned(
             val signature = stringList[2].decodeToByteArray(Base64UrlStrict)
                 .let { bytes ->
                     when (header.algorithm) {
-                        JwsAlgorithm.ES256, JwsAlgorithm.ES384, JwsAlgorithm.ES512 -> CryptoSignature.EC(bytes)
+                        JwsAlgorithm.ES256, JwsAlgorithm.ES384, JwsAlgorithm.ES512 -> CryptoSignature.EC.fromRawBytes(header.algorithm.toCryptoAlgorithm().curve!!,bytes)
                         else -> CryptoSignature.RSAorHMAC(bytes)
                     }
                 }

--- a/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
+++ b/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
@@ -12,9 +12,10 @@ val JweEncryption.jcaKeySpecName
         JweEncryption.A128CBC_HS256, JweEncryption.A192CBC_HS384, JweEncryption.A256CBC_HS512 -> "AES"
     }
 
-val JweAlgorithm.jcaName
+val JweAlgorithm.jcaName:String?
     get() = when (this) {
         JweAlgorithm.ECDH_ES -> "ECDH"
         JweAlgorithm.A128KW, JweAlgorithm.A192KW, JweAlgorithm.A256KW -> "AES"
         JweAlgorithm.RSA_OAEP_256, JweAlgorithm.RSA_OAEP_384, JweAlgorithm.RSA_OAEP_512 -> "RSA/ECB/OAEPPadding"
+        is JweAlgorithm.UNKNOWN -> null
     }

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
@@ -131,5 +131,5 @@ private fun randomCertificate() = X509Certificate(
     CryptoSignature.EC.fromRS(
         BigInteger.fromByteArray(Random.nextBytes(16), Sign.POSITIVE),
         BigInteger.fromByteArray(Random.nextBytes(16), Sign.POSITIVE)
-    )
+    ).withCurve(CryptoAlgorithm.ES256.curve!!)
 )

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoAlgorithm.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoAlgorithm.kt
@@ -21,13 +21,12 @@ import kotlinx.serialization.encoding.Encoder
 val OID_ECDH_ES = ObjectIdentifier("1.3.132.1.12")
 
 @Serializable(with = CryptoAlgorithmSerializer::class)
-enum class CryptoAlgorithm(override val oid: ObjectIdentifier, val isEc: Boolean = false) : Asn1Encodable<Asn1Sequence>,
-    Identifiable {
+enum class CryptoAlgorithm(override val oid: ObjectIdentifier, val curve: ECCurve?=null) : Asn1Encodable<Asn1Sequence>, Identifiable {
 
     // ECDSA with SHA-size
-    ES256(KnownOIDs.ecdsaWithSHA256, true),
-    ES384(KnownOIDs.ecdsaWithSHA384, true),
-    ES512(KnownOIDs.ecdsaWithSHA512, true),
+    ES256(KnownOIDs.ecdsaWithSHA256, ECCurve.SECP_256_R_1),
+    ES384(KnownOIDs.ecdsaWithSHA384, ECCurve.SECP_384_R_1),
+    ES512(KnownOIDs.ecdsaWithSHA512, ECCurve.SECP_521_R_1),
 
     // HMAC-size with SHA-size
     HS256(KnownOIDs.hmacWithSHA256),
@@ -46,6 +45,8 @@ enum class CryptoAlgorithm(override val oid: ObjectIdentifier, val isEc: Boolean
 
     // RSASSA-PKCS1-v1_5 using SHA-1
     RS1(KnownOIDs.sha1WithRSAEncryption);
+
+    val isEc = curve != null
 
     private fun encodePSSParams(bits: Int): Asn1Sequence {
         val shaOid = when (bits) {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
@@ -164,6 +164,7 @@ sealed class CryptoSignature(
             }
 
             /** load from raw byte array (r and s concatenated), asserting that the size fits this particular curve */
+            @Throws(IllegalArgumentException::class)
             fun fromRawBytes(curve: ECCurve, input: ByteArray): EC.DefiniteLength {
                 val sz = curve.scalarLength.bytes.toInt()
                 require(input.size == sz * 2)

--- a/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
+++ b/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
@@ -139,7 +139,7 @@ val CryptoSignature.jcaSignatureBytes: ByteArray
  */
 fun CryptoSignature.Companion.parseFromJca(input: ByteArray, algorithm: CryptoAlgorithm) =
     if (algorithm.isEc)
-        CryptoSignature.decodeFromDer(input)
+        CryptoSignature.EC.decodeFromDer(input).withCurve(algorithm.curve!!)
     else
         CryptoSignature.RSAorHMAC(input)
 

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
@@ -82,7 +82,7 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
         }.sign()
-        val test = CryptoSignature.decodeFromDer(signed)
+        val test = (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         val kotlinEncoded = x509Certificate.encodeToDer()
@@ -128,7 +128,7 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
         }.sign()
-        val test = CryptoSignature.decodeFromDer(signed)
+        val test = (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         repeat(500) { launch { x509Certificate.toJcaCertificate().getOrThrow().toKmpCertificate().getOrThrow().encodeToDer() shouldBe x509Certificate.encodeToDer() } }
@@ -136,8 +136,8 @@ class X509CertificateJvmTest : FreeSpec({
 
     "Certificate can be parsed" {
         val ecPublicKey = keyPair.public as ECPublicKey
-        val keyX = ecPublicKey.w.affineX.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
-        val keyY = ecPublicKey.w.affineY.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
+        val keyX = ecPublicKey.w.affineX.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
+        val keyY = ecPublicKey.w.affineY.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
 
         // create certificate with bouncycastle
         val notBeforeDate = Date.from(Instant.now())
@@ -348,9 +348,9 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate3.encodeToTlv().derEncoded)
         }.sign()
-        val signature1 = CryptoSignature.decodeFromDer(signed1)
-        val signature2 = CryptoSignature.decodeFromDer(signed2)
-        val signature3 = CryptoSignature.decodeFromDer(signed3)
+        val signature1 = (CryptoSignature.decodeFromDer(signed1) as  CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val signature2 = (CryptoSignature.decodeFromDer(signed2) as  CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val signature3 = (CryptoSignature.decodeFromDer(signed3) as  CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_521_R_1)
         val x509Certificate1 = X509Certificate(tbsCertificate1, signatureAlgorithm256, signature1)
         val x509Certificate2 = X509Certificate(tbsCertificate2, signatureAlgorithm256, signature2)
         val x509Certificate3 = X509Certificate(tbsCertificate3, signatureAlgorithm512, signature3)


### PR DESCRIPTION
Fixes for the little things that turned out to be missing when consuming the current development state of this library 

 * add `.didEncoded` shorthand to JWK which may return null, if encoding fails
 * add `.curve` to EC CryptoAlgorithms
 * Change JweAlgorithm to sealed class to support unknown algorithms
