### PR TITLE
Cleanups before Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@
 
 **Fixes**
  * Move `curve` from `CryptoAlgorithm` to `JwsAlgorithm`
- * Don't read curve information into the X.509 tea leaves where none exists
+ * Don't assume curve information for the X.509 signature when, in fact, none exists
    * `CryptoSignature`s in X.509 are now indefinite length
  * Changes
    * Rename `CryptoAlgorithm` to `X509SignatureAlgorithm` to better describe what it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,12 +139,13 @@
  * Add generic `ECPoint` class
  * Implement elliptic-curve arithmetic
 
-### NEXT
+
+### 3.2.0
 
 * Kotlin 2.0
 * Gradle 8.8
 * Bouncy Castle 1.78.1
-* kotest 5.9.1 
+* Kotest 5.9.1 
 * Coroutines 1.8.1
 * Serialization 1.7.1-SNAPSHOT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,5 +154,9 @@
  * Move `curve` from `CryptoAlgorithm` to `JwsAlgorithm`
  * Don't read curve information into the X.509 tea leaves where none exists
    * `CryptoSignature`s in X.509 are now indefinite length
- * Rename `CryptoAlgorithm` to `X509SignatureAlgorithm` to better describe what it is
-   * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly
+ * Changes
+   * Rename `CryptoAlgorithm` to `X509SignatureAlgorithm` to better describe what it is
+     * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly
+   * Rework CryptoSignature to two-dimensional interface:
+     * CryptoSignature <- {EC <- {IndefiniteLength, DefiniteLength}, RsaOrHmac}
+     * CryptoSignature <- {Defined <- {Ill <- EC.IndefiniteLength, Well <- {EC.DefiniteLength, RsaOrHmac}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@
    * `CryptoSignature`s in X.509 are now indefinite length
 
 **Changes**
-* Drop support for did-encoding uncompressed keys (but keep decoding support)
+* Always DID-encode keys in compressed form (but keep decoding support)
 * Rename `CryptoAlgorithm` to `X509SignatureAlgorithm` to better describe what it is
   * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly
 * Rework CryptoSignature to two-dimensional interface:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,3 +155,4 @@
  * Don't read curve information into the X.509 tea leaves where none exists
    * `CryptoSignature`s in X.509 are now indefinite length
  * Rename `CryptoAlgorithm` to `X509SignatureAlgorithm` to better describe what it is
+   * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,9 +154,11 @@
  * Move `curve` from `CryptoAlgorithm` to `JwsAlgorithm`
  * Don't assume curve information for the X.509 signature when, in fact, none exists
    * `CryptoSignature`s in X.509 are now indefinite length
- * Changes
-   * Rename `CryptoAlgorithm` to `X509SignatureAlgorithm` to better describe what it is
-     * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly
-   * Rework CryptoSignature to two-dimensional interface:
-     * CryptoSignature <- {EC <- {IndefiniteLength, DefiniteLength}, RsaOrHmac}
-     * CryptoSignature <- {Defined <- {Ill <- EC.IndefiniteLength, Well <- {EC.DefiniteLength, RsaOrHmac}}
+
+**Changes**
+* Drop support for did-encoding uncompressed keys (but keep decoding support)
+* Rename `CryptoAlgorithm` to `X509SignatureAlgorithm` to better describe what it is
+  * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly
+* Rework CryptoSignature to two-dimensional interface:
+  * CryptoSignature <- {EC <- {IndefiniteLength, DefiniteLength}, RsaOrHmac}
+  * CryptoSignature <- {Defined <- {Ill <- EC.IndefiniteLength, Well <- {EC.DefiniteLength, RsaOrHmac}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 * Kotest 5.9.1 
 * Coroutines 1.8.1
 * Serialization 1.7.1-SNAPSHOT
+* KmmResult 1.6.1
 
 **Fixes**
  * Move `curve` from `CryptoAlgorithm` to `JwsAlgorithm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,4 +161,4 @@
   * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly
 * Rework CryptoSignature to two-dimensional interface:
   * CryptoSignature <- {EC <- {IndefiniteLength, DefiniteLength}, RsaOrHmac}
-  * CryptoSignature <- {Defined <- {Ill <- EC.IndefiniteLength, Well <- {EC.DefiniteLength, RsaOrHmac}}
+  * CryptoSignature <- {RawByteEncodable <- {EC.DefiniteLength, RsaOrHmac}, NotRawByteEncodable <- EC.IndefiniteLength}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 plugins {
-    id("at.asitplus.gradle.conventions") version "2.0.0+20240607"
+    id("at.asitplus.gradle.conventions") version "2.0.0+20240610"
 }
 group = "at.asitplus.crypto"
 
@@ -18,11 +18,4 @@ tasks.getByName("dokkaHtmlMultiModule") {
 allprojects {
     apply(plugin = "org.jetbrains.dokka")
     group = rootProject.group
-
-    repositories {
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-            name = "bigNum"
-        }
-    }
 }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CborWebToken.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CborWebToken.kt
@@ -1,17 +1,13 @@
 package at.asitplus.crypto.datatypes.cose
 
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Instant
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.cbor.ByteString
 import kotlinx.serialization.cbor.CborLabel
-import kotlinx.serialization.decodeFromByteArray
-import kotlinx.serialization.encodeToByteArray
 
 /**
  * RFC 8392: CBOR Web Token (CWT)
@@ -101,8 +97,8 @@ data class CborWebToken(
     }
 
     companion object {
-        fun deserialize(it: ByteArray) = runCatching {
+        fun deserialize(it: ByteArray) = catching {
             cborSerializer.decodeFromByteArray<CborWebToken>(it)
-        }.wrap()
+        }
     }
 }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseAlgorithm.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseAlgorithm.kt
@@ -36,7 +36,7 @@ enum class CoseAlgorithm(val value: Int) {
     RS1(-65535);
 
 
-    fun toCryptoAlgorithm() = when (this) {
+    fun toX509SignatureAlgorithm() = when (this) {
         ES256 -> X509SignatureAlgorithm.ES256
         ES384 -> X509SignatureAlgorithm.ES384
         ES512 -> X509SignatureAlgorithm.ES512

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseAlgorithm.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseAlgorithm.kt
@@ -36,7 +36,7 @@ enum class CoseAlgorithm(val value: Int) {
     RS1(-65535);
 
 
-    fun toCryptoAlgorithm() = when(this) {
+    fun toCryptoAlgorithm() = when (this) {
         ES256 -> X509SignatureAlgorithm.ES256
         ES384 -> X509SignatureAlgorithm.ES384
         ES512 -> X509SignatureAlgorithm.ES512
@@ -73,7 +73,7 @@ object CoseAlgorithmSerializer : KSerializer<CoseAlgorithm> {
 
 }
 
-fun X509SignatureAlgorithm.toCoseAlgorithm() = when(this) {
+fun X509SignatureAlgorithm.toCoseAlgorithm() = when (this) {
     X509SignatureAlgorithm.ES256 -> CoseAlgorithm.ES256
     X509SignatureAlgorithm.ES384 -> CoseAlgorithm.ES384
     X509SignatureAlgorithm.ES512 -> CoseAlgorithm.ES512

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseHeader.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseHeader.kt
@@ -1,16 +1,12 @@
 package at.asitplus.crypto.datatypes.cose
 
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.cbor.ByteString
 import kotlinx.serialization.cbor.CborLabel
-import kotlinx.serialization.decodeFromByteArray
-import kotlinx.serialization.encodeToByteArray
 
 /**
  * Protected header of a [CoseSigned].
@@ -100,8 +96,8 @@ data class CoseHeader(
     }
 
     companion object {
-        fun deserialize(it: ByteArray) = kotlin.runCatching {
+        fun deserialize(it: ByteArray) = catching {
             cborSerializer.decodeFromByteArray<CoseHeader>(it)
-        }.wrap()
+        }
     }
 }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
@@ -131,7 +131,7 @@ data class CoseKey(
             y: ByteArray
         ): KmmResult<CoseKey> =
             runCatching {
-                CryptoPublicKey.EC(curve.toEcCurve(), x, y).toCoseKey()
+                CryptoPublicKey.EC.fromUncompressed(curve.toEcCurve(), x, y).toCoseKey()
                     .getOrThrow()
             }.wrap()
     }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
@@ -144,7 +144,7 @@ data class CoseKey(
 fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null): KmmResult<CoseKey> =
     when (this) {
         is CryptoPublicKey.EC ->
-            if ((algorithm != null) && !(algorithm.toCryptoAlgorithm().isEc))
+            if ((algorithm != null) && !(algorithm.toX509SignatureAlgorithm().isEc))
                 failure(IllegalArgumentException("Algorithm and Key Type mismatch"))
             else {
                 val keyParams = if (this.preferCompressedRepresentation) {

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
@@ -2,11 +2,9 @@ package at.asitplus.crypto.datatypes.cose
 
 import at.asitplus.KmmResult
 import at.asitplus.KmmResult.Companion.failure
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.asn1.decodeFromDer
-import at.asitplus.crypto.datatypes.misc.ANSIECPrefix
-import com.ionspin.kotlin.bignum.integer.Sign
 
 /**
  * Wrapper to handle parameters for different COSE public key types.
@@ -89,13 +87,13 @@ sealed class CoseKeyParams {
         override fun yHashCode(): Int = y?.contentHashCode() ?: 0
 
         override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> {
-            return runCatching {
+            return catching {
                 CryptoPublicKey.EC.fromUncompressed(
                     curve = curve?.toEcCurve() ?: throw IllegalArgumentException("Missing or invalid curve"),
                     x = x ?: throw IllegalArgumentException("Missing x-coordinate"),
                     y = y ?: throw IllegalArgumentException("Missing y-coordinate")
                 )
-            }.wrap()
+            }
         }
     }
 
@@ -120,12 +118,12 @@ sealed class CoseKeyParams {
 
         override fun yHashCode(): Int = y?.hashCode() ?: 0
 
-        override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> = runCatching {
+        override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> = catching {
             val curve = curve ?: throw Exception("Cannot determine Curve - Missing Curve")
             val x = x ?: throw Exception("Cannot determine key - Missing x coordinate")
             val yFlag = y ?: throw Exception("Cannot determine key - Missing Indicator y")
             CryptoPublicKey.EC.fromCompressed(curve.toEcCurve(), x, yFlag)
-        }.wrap()
+        }
     }
 
     /**
@@ -166,13 +164,13 @@ sealed class CoseKeyParams {
         }
 
         override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> {
-            return runCatching {
+            return catching {
                 CryptoPublicKey.Rsa(
                     n = n ?: throw IllegalArgumentException("Missing modulus n"),
                     e = e?.let { bytes -> Int.decodeFromDer(bytes) }
                         ?: throw IllegalArgumentException("Missing or invalid exponent e")
                 )
-            }.wrap()
+            }
         }
     }
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
@@ -165,8 +165,8 @@ sealed class CoseKeyParams {
         override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> = catching {
             CryptoPublicKey.Rsa(
                 n = n ?: throw IllegalArgumentException("Missing modulus n"),
-                e = e?.let { bytes -> Int.decodeFromDer(bytes) }
-                    ?: throw IllegalArgumentException("Missing or invalid exponent e")
+                e = Int.decodeFromDer(e ?:
+                    throw IllegalArgumentException("Missing or invalid exponent e"))
             )
         }
     }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
@@ -90,7 +90,7 @@ sealed class CoseKeyParams {
 
         override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> {
             return runCatching {
-                CryptoPublicKey.EC(
+                CryptoPublicKey.EC.fromUncompressed(
                     curve = curve?.toEcCurve() ?: throw IllegalArgumentException("Missing or invalid curve"),
                     x = x ?: throw IllegalArgumentException("Missing x-coordinate"),
                     y = y ?: throw IllegalArgumentException("Missing y-coordinate")
@@ -124,8 +124,7 @@ sealed class CoseKeyParams {
             val curve = curve ?: throw Exception("Cannot determine Curve - Missing Curve")
             val x = x ?: throw Exception("Cannot determine key - Missing x coordinate")
             val yFlag = y ?: throw Exception("Cannot determine key - Missing Indicator y")
-            CryptoPublicKey.EC(curve.toEcCurve(), x, yFlag)
-
+            CryptoPublicKey.EC.fromCompressed(curve.toEcCurve(), x, yFlag)
         }.wrap()
     }
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -43,7 +43,7 @@ data class CoseSigned(
         signature: CryptoSignature.Defined.Well
     ) : this(protectedHeader, unprotectedHeader, payload, signature.rawByteArray)
 
-    val signature: CryptoSignature by lazy {
+    val signature: CryptoSignature.Defined by lazy {
         if (protectedHeader.value.usesEC() ?: unprotectedHeader?.usesEC() ?: (rawSignature.size < 2048))
             CryptoSignature.EC.fromRawBytes(rawSignature)
         else CryptoSignature.RSAorHMAC(rawSignature)

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -89,7 +89,7 @@ data class CoseSigned(
 }
 
 fun CoseHeader.usesEC(): Boolean? {
-    algorithm?.toCryptoAlgorithm()?.isEc?.let { return it }
+    algorithm?.toX509SignatureAlgorithm()?.isEc?.let { return it }
     certificateChain?.let { return X509Certificate.decodeFromDerOrNull(it)?.publicKey is CryptoPublicKey.EC }
     return null
 }

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -40,7 +40,7 @@ data class CoseSigned(
         protectedHeader: ByteStringWrapper<CoseHeader>,
         unprotectedHeader: CoseHeader?,
         payload: ByteArray?,
-        signature: CryptoSignature
+        signature: CryptoSignature.Defined.Well
     ) : this(protectedHeader, unprotectedHeader, payload, signature.rawByteArray)
 
     val signature: CryptoSignature by lazy {

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -40,10 +40,10 @@ data class CoseSigned(
         protectedHeader: ByteStringWrapper<CoseHeader>,
         unprotectedHeader: CoseHeader?,
         payload: ByteArray?,
-        signature: CryptoSignature.Defined.Well
+        signature: CryptoSignature.RawByteEncodable
     ) : this(protectedHeader, unprotectedHeader, payload, signature.rawByteArray)
 
-    val signature: CryptoSignature.Defined by lazy {
+    val signature: CryptoSignature by lazy {
         if (protectedHeader.value.usesEC() ?: unprotectedHeader?.usesEC() ?: (rawSignature.size < 2048))
             CryptoSignature.EC.fromRawBytes(rawSignature)
         else CryptoSignature.RSAorHMAC(rawSignature)

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -1,25 +1,20 @@
 package at.asitplus.crypto.datatypes.cose
 
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.CryptoSignature
 import at.asitplus.crypto.datatypes.cose.io.Base16Strict
 import at.asitplus.crypto.datatypes.cose.io.cborSerializer
 import at.asitplus.crypto.datatypes.pki.X509Certificate
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.cbor.ByteString
 import kotlinx.serialization.cbor.ByteStringWrapper
 import kotlinx.serialization.cbor.CborArray
-import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
@@ -87,9 +82,9 @@ data class CoseSigned(
     }
 
     companion object {
-        fun deserialize(it: ByteArray) = kotlin.runCatching {
+        fun deserialize(it: ByteArray) = catching {
             cborSerializer.decodeFromByteArray<CoseSigned>(it)
-        }.wrap()
+        }
     }
 }
 
@@ -148,9 +143,9 @@ data class CoseSignatureInput(
 
 
     companion object {
-        fun deserialize(it: ByteArray) = kotlin.runCatching {
+        fun deserialize(it: ByteArray) = catching {
             cborSerializer.decodeFromByteArray<CoseSignatureInput>(it)
-        }.wrap()
+        }
     }
 }
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -50,7 +50,7 @@ data class CoseSigned(
 
     val signature: CryptoSignature by lazy {
         if (protectedHeader.value.usesEC() ?: unprotectedHeader?.usesEC() ?: (rawSignature.size < 2048))
-            CryptoSignature.EC(rawSignature)
+            CryptoSignature.EC.fromRawBytes(rawSignature)
         else CryptoSignature.RSAorHMAC(rawSignature)
     }
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseSigned.kt
@@ -88,11 +88,9 @@ data class CoseSigned(
     }
 }
 
-fun CoseHeader.usesEC(): Boolean? {
-    algorithm?.toX509SignatureAlgorithm()?.isEc?.let { return it }
-    certificateChain?.let { return X509Certificate.decodeFromDerOrNull(it)?.publicKey is CryptoPublicKey.EC }
-    return null
-}
+fun CoseHeader.usesEC(): Boolean? = algorithm?.toX509SignatureAlgorithm()?.isEc
+    ?: certificateChain?.let { X509Certificate.decodeFromDerOrNull(it)?.publicKey is CryptoPublicKey.EC }
+
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable

--- a/datatypes-cose/src/jvmTest/kotlin/CoseKeySerializationTest.kt
+++ b/datatypes-cose/src/jvmTest/kotlin/CoseKeySerializationTest.kt
@@ -28,14 +28,15 @@ class CoseKeySerializationTest : FreeSpec({
 
     "Serializing" - {
         "Manual" - {
-            val compressed = cborSerializer.encodeToByteArray( CryptoPublicKey.fromJcaPublicKey(
+            val compressed = cborSerializer.encodeToByteArray(CryptoPublicKey.fromJcaPublicKey(
                 KeyPairGenerator.getInstance("EC").apply {
                     initialize(256)
                 }.genKeyPair().public
             ).getOrThrow().run {
                 this as CryptoPublicKey.EC
                 this.copy(preferCompressedRepresentation = true)
-            }.toCoseKey(CoseAlgorithm.ES256).getOrThrow())
+            }.toCoseKey(CoseAlgorithm.ES256).getOrThrow()
+            )
             val coseUncompressed = CryptoPublicKey.fromJcaPublicKey(
                 KeyPairGenerator.getInstance("EC").apply {
                     initialize(256)
@@ -107,8 +108,8 @@ class CoseKeySerializationTest : FreeSpec({
                         decoded.toCryptoPublicKey().getOrThrow()
                             .getJcaPublicKey()
                             .getOrThrow().encoded.encodeToString(
-                            Base64Strict
-                        ) shouldBe pubKey.encoded.encodeToString(Base64Strict)
+                                Base64Strict
+                            ) shouldBe pubKey.encoded.encodeToString(Base64Strict)
                     }
 
                     withClue("Compressed")
@@ -131,8 +132,8 @@ class CoseKeySerializationTest : FreeSpec({
                         decoded.toCryptoPublicKey().getOrThrow()
                             .getJcaPublicKey()
                             .getOrThrow().encoded.encodeToString(
-                            Base64Strict
-                        ) shouldBe pubKey.encoded.encodeToString(Base64Strict)
+                                Base64Strict
+                            ) shouldBe pubKey.encoded.encodeToString(Base64Strict)
                     }
                 }
             }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebAlgorithm.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebAlgorithm.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.jws
 
+import at.asitplus.catching
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -8,6 +9,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = JwaSerializer::class)
 interface JsonWebAlgorithm {
     val identifier: String
@@ -27,9 +29,9 @@ object JwaSerializer : KSerializer<JsonWebAlgorithm> {
 
     override fun deserialize(decoder: Decoder): JsonWebAlgorithm {
         val decoded = decoder.decodeString()
-        return kotlin.runCatching { JwsAlgorithm.entries.first { it.identifier == decoded } }
+        return catching<JsonWebAlgorithm> { JwsAlgorithm.entries.first { it.identifier == decoded } }
             .getOrElse {
-                kotlin.runCatching {
+                catching<JsonWebAlgorithm> {
                     JweAlgorithm.entries.first { it.identifier == decoded }
                 }.getOrElse { JsonWebAlgorithm.UNKNOWN(decoded) }
             }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -3,8 +3,9 @@
 package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.KmmResult
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
+import at.asitplus.crypto.datatypes.CryptoPublicKey.EC.Companion.fromUncompressed
 import at.asitplus.crypto.datatypes.ECCurve
 import at.asitplus.crypto.datatypes.asn1.decodeFromDer
 import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
@@ -281,10 +282,10 @@ data class JsonWebKey(
      * (i.e. if all key params are set), or the first error.
      */
     fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> =
-        runCatching {
+        catching {
             when (type) {
                 JwkType.EC -> {
-                    CryptoPublicKey.EC(
+                    fromUncompressed(
                         curve = curve ?: throw IllegalArgumentException("Missing or invalid curve"),
                         x = x ?: throw IllegalArgumentException("Missing x-coordinate"),
                         y = y ?: throw IllegalArgumentException("Missing y-coordinate")
@@ -301,23 +302,23 @@ data class JsonWebKey(
 
                 else -> throw IllegalArgumentException("Illegal key type")
             }
-        }.wrap()
+        }
 
     /**
      * Contains convenience functions
      */
     companion object {
         fun deserialize(it: String): KmmResult<JsonWebKey> =
-            runCatching { jsonSerializer.decodeFromString<JsonWebKey>(it) }.wrap()
+            catching { jsonSerializer.decodeFromString<JsonWebKey>(it) }
 
         fun fromDid(input: String): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.fromDid(input).also { it.jwkId = input }.toJsonWebKey() }.wrap()
+            catching { CryptoPublicKey.fromDid(input).also { it.jwkId = input }.toJsonWebKey() }
 
         fun fromIosEncoded(bytes: ByteArray): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.fromIosEncoded(bytes).toJsonWebKey() }.wrap()
+            catching { CryptoPublicKey.fromIosEncoded(bytes).toJsonWebKey() }
 
         fun fromCoordinates(curve: ECCurve, x: ByteArray, y: ByteArray): KmmResult<JsonWebKey> =
-            runCatching { CryptoPublicKey.EC(curve, x, y).toJsonWebKey() }.wrap()
+            catching { fromUncompressed(curve, x, y).toJsonWebKey() }
     }
 }
 

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -281,28 +281,27 @@ data class JsonWebKey(
      * @return a KmmResult wrapped [CryptoPublicKey] equivalent if conversion is possible
      * (i.e. if all key params are set), or the first error.
      */
-    fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> =
-        catching {
-            when (type) {
-                JwkType.EC -> {
-                    fromUncompressed(
-                        curve = curve ?: throw IllegalArgumentException("Missing or invalid curve"),
-                        x = x ?: throw IllegalArgumentException("Missing x-coordinate"),
-                        y = y ?: throw IllegalArgumentException("Missing y-coordinate")
-                    ).apply { jwkId = identifier }
-                }
-
-                JwkType.RSA -> {
-                    CryptoPublicKey.Rsa(
-                        n = n ?: throw IllegalArgumentException("Missing modulus n"),
-                        e = e?.let { bytes -> Int.decodeFromDer(bytes) }
-                            ?: throw IllegalArgumentException("Missing or invalid exponent e")
-                    ).apply { jwkId = identifier }
-                }
-
-                else -> throw IllegalArgumentException("Illegal key type")
+    fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> = catching {
+        when (type) {
+            JwkType.EC -> {
+                fromUncompressed(
+                    curve = curve ?: throw IllegalArgumentException("Missing or invalid curve"),
+                    x = x ?: throw IllegalArgumentException("Missing x-coordinate"),
+                    y = y ?: throw IllegalArgumentException("Missing y-coordinate")
+                ).apply { jwkId = identifier }
             }
+
+            JwkType.RSA -> {
+                CryptoPublicKey.Rsa(
+                    n = n ?: throw IllegalArgumentException("Missing modulus n"),
+                    e = e?.let { bytes -> Int.decodeFromDer(bytes) }
+                        ?: throw IllegalArgumentException("Missing or invalid exponent e")
+                ).apply { jwkId = identifier }
+            }
+
+            else -> throw IllegalArgumentException("Illegal key type")
         }
+    }
 
     /**
      * Contains convenience functions

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKeySet.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKeySet.kt
@@ -1,6 +1,6 @@
 package at.asitplus.crypto.datatypes.jws
 
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -15,14 +15,14 @@ data class JsonWebKeySet(
     val keys: Collection<JsonWebKey>,
 ) {
 
-    fun serialize() = kotlin.runCatching {
+    fun serialize() = catching {
         jsonSerializer.encodeToString(this)
-    }.wrap()
+    }
 
     companion object {
-        fun deserialize(it: String) = kotlin.runCatching {
+        fun deserialize(it: String) = catching {
             jsonSerializer.decodeFromString<JsonWebKeySet>(it)
-        }.wrap()
+        }
     }
 
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebToken.kt
@@ -2,7 +2,7 @@
 
 package at.asitplus.crypto.datatypes.jws
 
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.jws.io.InstantLongSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
@@ -85,8 +85,8 @@ data class JsonWebToken(
     }
 
     companion object {
-        fun deserialize(it: String) = runCatching {
+        fun deserialize(it: String) = catching {
             jsonSerializer.decodeFromString<JsonWebToken>(it)
-        }.wrap()
+        }
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweAlgorithm.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweAlgorithm.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.jws
 
+import at.asitplus.catching
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -8,6 +9,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = JweAlgorithmSerializer::class)
 sealed class JweAlgorithm(override val identifier: String) : JsonWebAlgorithm {
 
@@ -76,7 +78,7 @@ object JweAlgorithmSerializer : KSerializer<JweAlgorithm> {
 
     override fun deserialize(decoder: Decoder): JweAlgorithm {
         val decoded = decoder.decodeString()
-        return kotlin.runCatching { JweAlgorithm.entries.first { it.identifier == decoded } }.getOrElse {
+        return catching { JweAlgorithm.entries.first { it.identifier == decoded } }.getOrElse {
             JweAlgorithm.UNKNOWN(decoded)
         }
     }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweEncrypted.kt
@@ -1,8 +1,7 @@
 package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.KmmResult
-import at.asitplus.KmmResult.Companion.wrap
-import at.asitplus.crypto.datatypes.io.Base64Strict
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.io.Base64UrlStrict
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -61,7 +60,7 @@ data class JweEncrypted(
 
 
     companion object {
-        fun parse(it: String): KmmResult<JweEncrypted> = runCatching {
+        fun parse(it: String): KmmResult<JweEncrypted> = catching {
             val stringList = it.replace("[^A-Za-z0-9-_.]".toRegex(), "").split(".")
             if (stringList.size != 5) throw IllegalArgumentException("not five parts in input: $it")
             val headerAsParsed = stringList[0].decodeToByteArray(Base64UrlStrict)
@@ -71,6 +70,6 @@ data class JweEncrypted(
             val authTag = stringList[4].decodeToByteArray(Base64UrlStrict)
             val header = JweHeader.deserialize(headerAsParsed.decodeToString()).getOrThrow()
             JweEncrypted(header, headerAsParsed, encryptedKey, iv, ciphertext, authTag)
-        }.wrap()
+        }
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweHeader.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JweHeader.kt
@@ -1,6 +1,6 @@
 package at.asitplus.crypto.datatypes.jws
 
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64UrlSerializer
 import at.asitplus.crypto.datatypes.jws.io.jsonSerializer
 import at.asitplus.crypto.datatypes.pki.CertificateChain
@@ -283,8 +283,8 @@ data class JweHeader(
     }
 
     companion object {
-        fun deserialize(it: String) = kotlin.runCatching {
+        fun deserialize(it: String) = catching {
             jsonSerializer.decodeFromString<JweHeader>(it)
-        }.wrap()
+        }
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsAlgorithm.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsAlgorithm.kt
@@ -1,7 +1,7 @@
 package at.asitplus.crypto.datatypes.jws
 
-import at.asitplus.crypto.datatypes.X509SignatureAlgorithm
 import at.asitplus.crypto.datatypes.ECCurve
+import at.asitplus.crypto.datatypes.X509SignatureAlgorithm
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -15,7 +15,7 @@ import kotlinx.serialization.encoding.Encoder
  * Since we support only JWS algorithms (with one exception), this class is called what it's called.
  */
 @Serializable(with = JwsAlgorithmSerializer::class)
-enum class JwsAlgorithm(override val identifier: String):JsonWebAlgorithm {
+enum class JwsAlgorithm(override val identifier: String) : JsonWebAlgorithm {
 
     ES256("ES256"),
     ES384("ES384"),
@@ -60,12 +60,13 @@ enum class JwsAlgorithm(override val identifier: String):JsonWebAlgorithm {
 
     /** The curve to create signatures on.
      * This is fixed by RFC7518, as opposed to X.509 where other combinations are possible. */
-    val ecCurve: ECCurve? get() = when (this) {
-        ES256 -> ECCurve.SECP_256_R_1
-        ES384 -> ECCurve.SECP_384_R_1
-        ES512 -> ECCurve.SECP_521_R_1
-        else -> null
-    }
+    val ecCurve: ECCurve?
+        get() = when (this) {
+            ES256 -> ECCurve.SECP_256_R_1
+            ES384 -> ECCurve.SECP_384_R_1
+            ES512 -> ECCurve.SECP_521_R_1
+            else -> null
+        }
 }
 
 object JwsAlgorithmSerializer : KSerializer<JwsAlgorithm> {

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsAlgorithm.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsAlgorithm.kt
@@ -38,7 +38,7 @@ enum class JwsAlgorithm(override val identifier: String) : JsonWebAlgorithm {
      */
     NON_JWS_SHA1_WITH_RSA("RS1");
 
-    fun toCryptoAlgorithm() = when (this) {
+    fun toX509SignatureAlgorithm() = when (this) {
         ES256 -> X509SignatureAlgorithm.ES256
         ES384 -> X509SignatureAlgorithm.ES384
         ES512 -> X509SignatureAlgorithm.ES512

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsHeader.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsHeader.kt
@@ -2,7 +2,7 @@
 
 package at.asitplus.crypto.datatypes.jws
 
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64UrlSerializer
@@ -271,15 +271,15 @@ data class JwsHeader(
      */
     val publicKey: CryptoPublicKey? by lazy {
         jsonWebKey?.toCryptoPublicKey()?.getOrNull()
-            ?: keyId?.let { runCatching { CryptoPublicKey.fromDid(it) } }?.getOrNull()
+            ?: keyId?.let { catching { CryptoPublicKey.fromDid(it) } }?.getOrNull()
             ?: certificateChain?.leaf?.publicKey
     }
 
 
     companion object {
-        fun deserialize(it: String) = kotlin.runCatching {
+        fun deserialize(it: String) = catching {
             jsonSerializer.decodeFromString<JwsHeader>(it)
-        }.wrap()
+        }
 
     }
 }

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -15,7 +15,7 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 data class JwsSigned(
     val header: JwsHeader,
     val payload: ByteArray,
-    val signature: CryptoSignature.Defined.Well,
+    val signature: CryptoSignature.RawByteEncodable,
     val plainSignatureInput: String,
 ) {
 

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -1,7 +1,7 @@
 package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.KmmResult
-import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoSignature
 import at.asitplus.crypto.datatypes.io.Base64UrlStrict
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
@@ -50,7 +50,7 @@ data class JwsSigned(
 
 
     companion object {
-        fun parse(it: String): KmmResult<JwsSigned> = runCatching {
+        fun parse(it: String): KmmResult<JwsSigned> = catching {
             val stringList = it.replace("[^A-Za-z0-9-_.]".toRegex(), "").split(".")
             if (stringList.size != 3) throw IllegalArgumentException("not three parts in input: $it")
             val headerInput = stringList[0].decodeToByteArray(Base64UrlStrict)
@@ -67,7 +67,7 @@ data class JwsSigned(
                 }
             val plainSignatureInput = stringList[0] + "." + stringList[1]
             JwsSigned(header, payload, signature, plainSignatureInput)
-        }.wrap()
+        }
 
 
         /**

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JwsSigned.kt
@@ -15,7 +15,7 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 data class JwsSigned(
     val header: JwsHeader,
     val payload: ByteArray,
-    val signature: CryptoSignature,
+    val signature: CryptoSignature.Defined.Well,
     val plainSignatureInput: String,
 ) {
 

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/io/JwsCertificateSerializer.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 object JwsCertificateSerializer : KSerializer<X509Certificate> {
     override val descriptor: SerialDescriptor =

--- a/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
+++ b/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
@@ -3,7 +3,13 @@ package at.asitplus.crypto.datatypes.jws
 val JweEncryption.jcaName
     get() = when (this) {
         JweEncryption.A128GCM, JweEncryption.A192GCM, JweEncryption.A256GCM -> "AES/GCM/NoPadding"
-        JweEncryption.A128CBC_HS256, JweEncryption.A192CBC_HS384, JweEncryption.A256CBC_HS512 -> "AES/CBC/NoPadding"
+        JweEncryption.A128CBC_HS256, JweEncryption.A192CBC_HS384, JweEncryption.A256CBC_HS512 -> "AES/CBC/PKCS5Padding"
+    }
+
+val JweEncryption.isAuthenticatedEncryption
+    get() = when (this) {
+        JweEncryption.A128GCM, JweEncryption.A192GCM, JweEncryption.A256GCM -> true
+        JweEncryption.A128CBC_HS256, JweEncryption.A192CBC_HS384, JweEncryption.A256CBC_HS512 -> false
     }
 
 val JweEncryption.jcaKeySpecName

--- a/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
+++ b/datatypes-jws/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/jws/JcaExtensions.kt
@@ -12,7 +12,7 @@ val JweEncryption.jcaKeySpecName
         JweEncryption.A128CBC_HS256, JweEncryption.A192CBC_HS384, JweEncryption.A256CBC_HS512 -> "AES"
     }
 
-val JweAlgorithm.jcaName:String?
+val JweAlgorithm.jcaName: String?
     get() = when (this) {
         JweAlgorithm.ECDH_ES -> "ECDH"
         JweAlgorithm.A128KW, JweAlgorithm.A192KW, JweAlgorithm.A256KW -> "AES"

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKeyJvmTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKeyJvmTest.kt
@@ -1,11 +1,11 @@
 package at.asitplus.crypto.datatypes.jws
 
 import at.asitplus.crypto.datatypes.CryptoPublicKey
+import at.asitplus.crypto.datatypes.CryptoPublicKey.EC.Companion.fromUncompressed
 import at.asitplus.crypto.datatypes.ECCurve
 import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
 import at.asitplus.crypto.datatypes.asn1.ensureSize
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldHaveMinLength
@@ -27,9 +27,9 @@ class JsonWebKeyJvmTest : FreeSpec({
     }
 
     "JWK can be created from Coordinates" - {
-        val xFromBc = (keyPair.public as ECPublicKey).w.affineX.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
-        val yFromBc = (keyPair.public as ECPublicKey).w.affineY.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
-        val pubKey = CryptoPublicKey.EC(ecCurve, xFromBc, yFromBc).also { it.jwkId=it.didEncoded }
+        val xFromBc = (keyPair.public as ECPublicKey).w.affineX.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
+        val yFromBc = (keyPair.public as ECPublicKey).w.affineY.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
+        val pubKey = fromUncompressed(ecCurve, xFromBc, yFromBc).also { it.jwkId = it.didEncoded }
         val jsonWebKey = pubKey.toJsonWebKey()
 
         jsonWebKey.shouldNotBeNull()
@@ -55,7 +55,7 @@ class JsonWebKeyJvmTest : FreeSpec({
     "JWK can be created from n and e" - {
         val nFromBc = (keyPairRSA.public as RSAPublicKey).modulus.toByteArray()
         val eFromBc = (keyPairRSA.public as RSAPublicKey).publicExponent.toInt()
-        val pubKey = CryptoPublicKey.Rsa(nFromBc, eFromBc).also { it.jwkId=it.didEncoded }
+        val pubKey = CryptoPublicKey.Rsa(nFromBc, eFromBc).also { it.jwkId = it.didEncoded }
         val jwk = pubKey.toJsonWebKey()
 
         jwk.shouldNotBeNull()

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JweEncryptedTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JweEncryptedTest.kt
@@ -3,12 +3,7 @@ package at.asitplus.crypto.datatypes.jws
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.fromJcaPublicKey
 import at.asitplus.crypto.datatypes.io.Base64UrlStrict
-import com.nimbusds.jose.EncryptionMethod
-import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.JWEAlgorithm
-import com.nimbusds.jose.JWEHeader
-import com.nimbusds.jose.JWEObject
-import com.nimbusds.jose.Payload
+import com.nimbusds.jose.*
 import com.nimbusds.jose.crypto.AESEncrypter
 import com.nimbusds.jose.crypto.ECDHEncrypter
 import com.nimbusds.jose.jwk.Curve

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
@@ -1,12 +1,8 @@
 package at.asitplus.crypto.datatypes.jws
 
-import at.asitplus.crypto.datatypes.X509SignatureAlgorithm
-import at.asitplus.crypto.datatypes.CryptoPublicKey
-import at.asitplus.crypto.datatypes.CryptoSignature
-import at.asitplus.crypto.datatypes.ECCurve
+import at.asitplus.crypto.datatypes.*
 import at.asitplus.crypto.datatypes.asn1.Asn1String
 import at.asitplus.crypto.datatypes.asn1.Asn1Time
-import at.asitplus.crypto.datatypes.fromJcaPublicKey
 import at.asitplus.crypto.datatypes.io.Base64Strict
 import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue
 import at.asitplus.crypto.datatypes.pki.RelativeDistinguishedName
@@ -42,7 +38,8 @@ class JwkTest : FreeSpec({
                 keys
             ) { pubKey ->
 
-                val cryptoPubKey = CryptoPublicKey.EC.fromJcaPublicKey(pubKey).getOrThrow().also { it.jwkId=it.didEncoded }
+                val cryptoPubKey =
+                    CryptoPublicKey.EC.fromJcaPublicKey(pubKey).getOrThrow().also { it.jwkId = it.didEncoded }
                 val own = cryptoPubKey.toJsonWebKey()
                 own.keyId shouldBe cryptoPubKey.jwkId
                 own.shouldNotBeNull()

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
@@ -347,24 +347,29 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             }
 
             /** Decodes key from big-endian X and sign of Y */
+            @Suppress("NOTHING_TO_INLINE")
             inline fun fromCompressed(curve: ECCurve, x: ByteArray, sign: Sign) =
                 ECPoint.fromCompressed(curve, x, sign).asPublicKey(true)
 
             /** Decodes key from big-endian X and sign of Y */
+            @Suppress("NOTHING_TO_INLINE")
             inline fun fromCompressed(curve: ECCurve, x: ByteArray, usePositiveY: Boolean) =
                 ECPoint.fromCompressed(curve, x, usePositiveY).asPublicKey(true)
 
             /** Decodes key from big-endian X and big-endian Y */
+            @Suppress("NOTHING_TO_INLINE")
             inline fun fromUncompressed(curve: ECCurve, x: ByteArray, y: ByteArray) =
                 ECPoint.fromUncompressed(curve, x, y).asPublicKey(false)
 
             @Deprecated("Explicitly specify what you want",
                 ReplaceWith("fromCompressed(curve, x, usePositiveY)"))
+            @Suppress("NOTHING_TO_INLINE")
             inline operator fun invoke(curve: ECCurve, x: ByteArray, usePositiveY: Boolean) =
                 fromCompressed(curve, x, usePositiveY)
 
             @Deprecated("Explicitly specify what you want", ReplaceWith(
                 "fromUncompressed(curve, x, y)"))
+            @Suppress("NOTHING_TO_INLINE")
             inline operator fun invoke(curve: ECCurve, x: ByteArray, y: ByteArray) =
                 fromUncompressed(curve, x, y)
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
@@ -6,8 +6,9 @@ import at.asitplus.crypto.datatypes.asn1.Asn1.BitString
 import at.asitplus.crypto.datatypes.asn1.Asn1.Null
 import at.asitplus.crypto.datatypes.io.ByteArrayBase64Serializer
 import at.asitplus.crypto.datatypes.io.MultiBase
-import at.asitplus.crypto.datatypes.misc.*
+import at.asitplus.crypto.datatypes.misc.ANSIECPrefix
 import at.asitplus.crypto.datatypes.misc.ANSIECPrefix.Companion.hasPrefix
+import at.asitplus.crypto.datatypes.misc.UVarInt
 import com.ionspin.kotlin.bignum.integer.Sign
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -373,11 +374,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             inline operator fun invoke(curve: ECCurve, x: ByteArray, usePositiveY: Boolean) =
                 fromCompressed(curve, x, usePositiveY)
 
-            @Deprecated(
-                "Explicitly specify what you want", ReplaceWith(
-                    "fromUncompressed(curve, x, y)"
-                )
-            )
+            @Deprecated("Explicitly specify what you want", ReplaceWith("fromUncompressed(curve, x, y)"))
             @Suppress("NOTHING_TO_INLINE")
             inline operator fun invoke(curve: ECCurve, x: ByteArray, y: ByteArray) =
                 fromUncompressed(curve, x, y)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
@@ -72,13 +72,13 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             val keyBytes = decoded.copyOfRange(2, decoded.size)
 
             return when (codec) {
-                0x1200uL ->
+                0x1200uL, 0x1290uL ->
                     EC.fromAnsiX963Bytes(ECCurve.SECP_256_R_1, keyBytes)
 
-                0x1201uL ->
+                0x1201uL, 0x1291uL ->
                     EC.fromAnsiX963Bytes(ECCurve.SECP_384_R_1, keyBytes)
 
-                0x1202uL ->
+                0x1202uL, 0x1292uL ->
                     EC.fromAnsiX963Bytes(ECCurve.SECP_521_R_1, keyBytes)
 
                 0x1205uL ->

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoPublicKey.kt
@@ -330,7 +330,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             )
         }
 
-        override val iosEncoded by lazy { toAnsiX963Encoded() }
+        override val iosEncoded by lazy { toAnsiX963Encoded(useCompressed = false) }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
@@ -6,6 +6,7 @@ import at.asitplus.crypto.datatypes.asn1.DERTags.DER_SEQUENCE
 import at.asitplus.crypto.datatypes.io.Base64Strict
 import at.asitplus.crypto.datatypes.misc.BitLength
 import at.asitplus.crypto.datatypes.misc.max
+import at.asitplus.crypto.datatypes.pki.X509Certificate
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
@@ -28,9 +29,23 @@ import kotlinx.serialization.encoding.Encoder
 sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
     val signature: Asn1Element
 
+
+    /**
+     * Allows classifying CryptoSignatures into two classes
+     */
     sealed interface Defined : CryptoSignature {
+        /**
+         * Ill-defined CryptoSignatures cannot be encoded into raw byte arrays,
+         * since not all properties required to do so are known. For example, EC signatures parsed from an
+         * [X509Certificate] do not specify a curve.
+         */
         sealed interface Ill : Defined
 
+        /**
+         * Well-defined CryptoSignatures can be encoded into raw byte arrays,
+         * since all the information to do so is present. RSA Signatures and EC Signatures with a known curve fall into
+         * this category.
+         */
         sealed interface Well : Defined {
             /**
              * Removes ASN1 Structure and returns the value(s) as ByteArray

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
@@ -31,13 +31,18 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
 
 
     /**
-     * Allows classifying CryptoSignatures into two classes
+     * Allows separating [CryptoSignature]s into two **mutually exclusive** classes:
+     *  * [Ill]-defined signatures, which lack the information to be encoded into raw bytes
+     *  * [Well]-defined signatures, which can be freely encoded/decoded from/to raw bytes
      */
     sealed interface Defined : CryptoSignature {
         /**
          * Ill-defined CryptoSignatures cannot be encoded into raw byte arrays,
          * since not all properties required to do so are known. For example, EC signatures parsed from an
-         * [X509Certificate] do not specify a curve.
+         * [X509Certificate] do not specify a curve. Hence, it is impossible to know how the components should be padded
+         * before encoding it into raw bytes.
+         *
+         * **This is the opposite of a [Well]-defined signature**
          */
         sealed interface Ill : Defined
 
@@ -45,6 +50,8 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
          * Well-defined CryptoSignatures can be encoded into raw byte arrays,
          * since all the information to do so is present. RSA Signatures and EC Signatures with a known curve fall into
          * this category.
+         *
+         * **This is the opposite of an [Ill]-defined signature**
          */
         sealed interface Well : Defined {
             /**

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
@@ -58,9 +58,8 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
 
     override fun encodeToTlv(): Asn1Element = signature
 
-    fun str(): String {
-        return "${this::class.simpleName ?: "CryptoSignature"}(signature=${signature.prettyPrint()})"
-    }
+    val humanReadableString: String get() = "${this::class.simpleName ?: "CryptoSignature"}(signature=${signature.prettyPrint()})"
+
 
     object CryptoSignatureSerializer : KSerializer<CryptoSignature> {
         override val descriptor: SerialDescriptor
@@ -99,7 +98,7 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
             return ((this.s == other.s) && (this.r == other.r))
         }
 
-        override fun toString() = str()
+        override fun toString() = humanReadableString
 
         /** @see equals */
         override fun hashCode() = 31 * this.s.hashCode() + this.r.hashCode()
@@ -225,6 +224,8 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
         override fun encodeToTlvBitString(): Asn1Element = this.encodeToTlv()
 
         override fun hashCode(): Int = signature.hashCode()
+
+        override fun toString() = humanReadableString
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/CryptoSignature.kt
@@ -163,7 +163,7 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
                     "r is ${r.bitLength()} bits long, expected at most ${scalarByteLength.toInt()} bytes (${max} bits)"
                 }
 
-                require(s.bitLength() <= scalarByteLength.toInt() * 8) {
+                require(s.bitLength() <= max) {
                     "s is ${s.bitLength()} bits long, expected at most ${scalarByteLength.toInt()} bytes (${max} bits)"
                 }
             }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECCurve.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECCurve.kt
@@ -54,11 +54,11 @@ enum class ECCurve(
 
     @Deprecated("use scalarLength to express raw signature size", ReplaceWith("scalarLength.bytes * 2u"))
     /** the number of bytes needed to store a raw signature (r and s concatenated) over this curve */
-    inline val signatureLengthBytes: UInt get() = scalarLength.bytes*2u
+    inline val signatureLengthBytes: UInt get() = scalarLength.bytes * 2u
 
     internal val coordinateCreator by lazy { ModularBigInteger.creatorForModulo(this.modulus) }
     internal val scalarCreator by lazy { ModularBigInteger.creatorForModulo(this.order) }
-    
+
     /**
      * p: Prime modulus of the underlying prime field
      * See https://www.secg.org/sec2-v2.pdf
@@ -70,12 +70,12 @@ enum class ECCurve(
 
             SECP_384_R_1 ->
                 "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE" +
-                "FFFFFFFF 00000000 00000000 FFFFFFFF"
+                        "FFFFFFFF 00000000 00000000 FFFFFFFF"
 
             SECP_521_R_1 ->
-                    "01FF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
-                "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
-                "FFFFFFFF"
+                "01FF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
+                        "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
+                        "FFFFFFFF"
 
         }.replace(" ", "").toBigInteger(16)
     }
@@ -91,12 +91,12 @@ enum class ECCurve(
 
             SECP_384_R_1 ->
                 "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE" +
-                "FFFFFFFF 00000000 00000000 FFFFFFFC"
+                        "FFFFFFFF 00000000 00000000 FFFFFFFC"
 
             SECP_521_R_1 ->
-                    "01FF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
-                "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
-                "FFFFFFFC"
+                "01FF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
+                        "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
+                        "FFFFFFFC"
         }.let {
             coordinateCreator.parseString(string = it.replace(" ", ""), base = 16)
         }
@@ -113,12 +113,12 @@ enum class ECCurve(
 
             SECP_384_R_1 ->
                 "B3312FA7 E23EE7E4 988E056B E3F82D19 181D9C6E FE814112 0314088F 5013875A" +
-                "C656398D 8A2ED19D 2A85C8ED D3EC2AEF"
+                        "C656398D 8A2ED19D 2A85C8ED D3EC2AEF"
 
             SECP_521_R_1 ->
-                    "0051 953EB961 8E1C9A1F 929A21A0 B68540EE A2DA725B 99B315F3 B8B48991" +
-                "8EF109E1 56193951 EC7E937B 1652C0BD 3BB1BF07 3573DF88 3D2C34F1 EF451FD4" +
-                "6B503F00"
+                "0051 953EB961 8E1C9A1F 929A21A0 B68540EE A2DA725B 99B315F3 B8B48991" +
+                        "8EF109E1 56193951 EC7E937B 1652C0BD 3BB1BF07 3573DF88 3D2C34F1 EF451FD4" +
+                        "6B503F00"
         }.let {
             coordinateCreator.parseString(string = it.replace(" ", ""), base = 16)
         }
@@ -131,21 +131,23 @@ enum class ECCurve(
     val generator: ECPoint.Normalized by lazy {
         when (this) {
             SECP_256_R_1 ->
-                      "04 6B17D1F2 E12C4247 F8BCE6E5 63A440F2 77037D81 2DEB33A0" +
-                "F4A13945 D898C296 4FE342E2 FE1A7F9B 8EE7EB4A 7C0F9E16 2BCE3357" +
-                "6B315ECE CBB64068 37BF51F5"
+                "04 6B17D1F2 E12C4247 F8BCE6E5 63A440F2 77037D81 2DEB33A0" +
+                        "F4A13945 D898C296 4FE342E2 FE1A7F9B 8EE7EB4A 7C0F9E16 2BCE3357" +
+                        "6B315ECE CBB64068 37BF51F5"
+
             SECP_384_R_1 ->
-                     "04 AA87CA22 BE8B0537 8EB1C71E F320AD74 6E1D3B62 8BA79B98" +
-               "59F741E0 82542A38 5502F25D BF55296C 3A545E38 72760AB7 3617DE4A" +
-               "96262C6F 5D9E98BF 9292DC29 F8F41DBD 289A147C E9DA3113 B5F0B8C0" +
-               "0A60B1CE 1D7E819D 7A431D7C 90EA0E5F"
+                "04 AA87CA22 BE8B0537 8EB1C71E F320AD74 6E1D3B62 8BA79B98" +
+                        "59F741E0 82542A38 5502F25D BF55296C 3A545E38 72760AB7 3617DE4A" +
+                        "96262C6F 5D9E98BF 9292DC29 F8F41DBD 289A147C E9DA3113 B5F0B8C0" +
+                        "0A60B1CE 1D7E819D 7A431D7C 90EA0E5F"
+
             SECP_521_R_1 ->
-                     "04 00C6858E 06B70404 E9CD9E3E CB662395 B4429C64 8139053F" +
-               "B521F828 AF606B4D 3DBAA14B 5E77EFE7 5928FE1D C127A2FF A8DE3348" +
-               "B3C1856A 429BF97E 7E31C2E5 BD660118 39296A78 9A3BC004 5C8A5FB4" +
-               "2C7D1BD9 98F54449 579B4468 17AFBD17 273E662C 97EE7299 5EF42640" +
-               "C550B901 3FAD0761 353C7086 A272C240 88BE9476 9FD16650"
-        }.replace(" ","").chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+                "04 00C6858E 06B70404 E9CD9E3E CB662395 B4429C64 8139053F" +
+                        "B521F828 AF606B4D 3DBAA14B 5E77EFE7 5928FE1D C127A2FF A8DE3348" +
+                        "B3C1856A 429BF97E 7E31C2E5 BD660118 39296A78 9A3BC004 5C8A5FB4" +
+                        "2C7D1BD9 98F54449 579B4468 17AFBD17 273E662C 97EE7299 5EF42640" +
+                        "C550B901 3FAD0761 353C7086 A272C240 88BE9476 9FD16650"
+        }.replace(" ", "").chunked(2).map { it.toInt(16).toByte() }.toByteArray()
             .let { CryptoPublicKey.EC.fromAnsiX963Bytes(this, it).publicPoint }
     }
 
@@ -154,30 +156,33 @@ enum class ECCurve(
      * See https://www.secg.org/sec2-v2.pdf
      */
     val order: BigInteger by lazy {
-        when(this) {
+        when (this) {
             SECP_256_R_1 ->
                 "FFFFFFFF 00000000 FFFFFFFF FFFFFFFF BCE6FAAD A7179E84 F3B9CAC2" +
-                "FC632551"
+                        "FC632551"
+
             SECP_384_R_1 ->
                 "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF C7634D81" +
-                "F4372DDF 581A0DB2 48B0A77A ECEC196A CCC52973"
+                        "F4372DDF 581A0DB2 48B0A77A ECEC196A CCC52973"
+
             SECP_521_R_1 ->
                 "01FF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
-                "FFFFFFFF FFFFFFFA 51868783 BF2F966B 7FCC0148 F709A5D0 3BB5C9B8" +
-                "899C47AE BB6FB71E 91386409"
-        }.replace (" ", "").toBigInteger(16)
+                        "FFFFFFFF FFFFFFFA 51868783 BF2F966B 7FCC0148 F709A5D0 3BB5C9B8" +
+                        "899C47AE BB6FB71E 91386409"
+        }.replace(" ", "").toBigInteger(16)
     }
 
     /**
      * h: Cofactor of the cyclic subgroup generated by G
      * See https://www.secg.org/sec2-v2.pdf
      */
-    val cofactor: Int get() =
-        when(this) {
-            SECP_256_R_1 -> 1
-            SECP_384_R_1 -> 1
-            SECP_521_R_1 -> 1
-        }
+    val cofactor: Int
+        get() =
+            when (this) {
+                SECP_256_R_1 -> 1
+                SECP_384_R_1 -> 1
+                SECP_521_R_1 -> 1
+            }
 
     companion object {
         fun of(bits: UInt) = entries.find { it.scalarLength.bits == bits }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECCurve.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECCurve.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@Suppress("NOTHING_TO_INLINE")
 inline fun UInt.ceilDiv(other: UInt) =
     (floorDiv(other)) + (if (rem(other) != 0u) 1u else 0u)
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECPoint.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECPoint.kt
@@ -91,9 +91,7 @@ sealed class ECPoint private constructor(
             "ECPoint[$curve]: (${homX.toString(16)} : ${homY.toString(16)}) [normalized]"
         else
             "ECPoint[$curve]: (${(homX / homZ).toString(16)} : ${(homY / homZ).toString(16)}) [with Z = ${
-                homZ.toString(
-                    16
-                )
+                homZ.toString(16)
             }]"
 
     override fun equals(other: Any?): Boolean {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECPoint.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECPoint.kt
@@ -104,6 +104,7 @@ sealed class ECPoint private constructor(
 
     /** whether this is the additive identity (point at infinity). the point at infinity cannot be normalized. */
     val isPointAtInfinity inline get() = this.homZ.isZero()
+
     /** normalizes this point, converting it to affine coordinates. throws for the point at infinity.
      * @see tryNormalize */
     fun normalize(): Normalized {
@@ -113,6 +114,7 @@ sealed class ECPoint private constructor(
     }
     /** normalizes this point, converting it to affine coordinates. returns null for the point at infinity.
      * @see normalize */
+    @Suppress("NOTHING_TO_INLINE")
     inline fun tryNormalize() = if (!this.isPointAtInfinity) normalize() else null
 
     companion object {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECPoint.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/ECPoint.kt
@@ -46,11 +46,12 @@ sealed class ECPoint private constructor(
     val homZ: ModularBigInteger
 ) {
 
-    class General private constructor (
+    class General private constructor(
         c: ECCurve, hX: ModularBigInteger, hY: ModularBigInteger, hZ: ModularBigInteger
     ) : ECPoint(c, hX, hY, hZ) {
         companion object {
-            @PublishedApi @JvmSynthetic
+            @PublishedApi
+            @JvmSynthetic
             internal fun unsafeFromXYZ(c: ECCurve, x: ModularBigInteger, y: ModularBigInteger, z: ModularBigInteger) =
                 General(c, x, y, z)
         }
@@ -65,6 +66,7 @@ sealed class ECPoint private constructor(
     ) : ECPoint(curve, x, y, curve.coordinateCreator.ONE) {
         /** x coordinate of the point (x,y) */
         val x inline get() = homX
+
         /** y coordinate of the point (x,y) */
         val y inline get() = homY
 
@@ -75,7 +77,8 @@ sealed class ECPoint private constructor(
         override fun hashCode() = (31 * (31 * curve.hashCode()) + x.hashCode()) + y.hashCode()
 
         companion object {
-            @PublishedApi @JvmSynthetic
+            @PublishedApi
+            @JvmSynthetic
             internal fun unsafeFromXY(curve: ECCurve, x: ModularBigInteger, y: ModularBigInteger) =
                 Normalized(curve, x, y)
         }
@@ -87,7 +90,11 @@ sealed class ECPoint private constructor(
         else if (this is Normalized)
             "ECPoint[$curve]: (${homX.toString(16)} : ${homY.toString(16)}) [normalized]"
         else
-            "ECPoint[$curve]: (${(homX/homZ).toString(16)} : ${(homY/homZ).toString(16)}) [with Z = ${homZ.toString(16)}]"
+            "ECPoint[$curve]: (${(homX / homZ).toString(16)} : ${(homY / homZ).toString(16)}) [with Z = ${
+                homZ.toString(
+                    16
+                )
+            }]"
 
     override fun equals(other: Any?): Boolean {
         if (other !is ECPoint) return false
@@ -112,6 +119,7 @@ sealed class ECPoint private constructor(
         if (this.isPointAtInfinity) throw IllegalStateException("Cannot normalize point at infinity")
         return Normalized.unsafeFromXY(curve, homX / homZ, homY / homZ)
     }
+
     /** normalizes this point, converting it to affine coordinates. returns null for the point at infinity.
      * @see normalize */
     @Suppress("NOTHING_TO_INLINE")

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/X509SignatureAlgorithm.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/X509SignatureAlgorithm.kt
@@ -12,15 +12,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-
-/**
- * ECDH_ES (1.3.132.1.12) as per [draft-ietf-jose-json-web-algorithms-26](https://datatracker.ietf.org/doc/html/draft-ietf-jose-json-web-algorithms-26)
- *
- * This constant lives here, because we also need it in the commons module to be able to map this JWS Algorithm to a CryptoAlgorithm.
- * (It cannot be put into the compilation, since it is needed for enum init).
- */
-val OID_ECDH_ES = ObjectIdentifier("1.3.132.1.12")
-
 @Serializable(with = X509SignatureAlgorithmSerializer::class)
 enum class X509SignatureAlgorithm(override val oid: ObjectIdentifier, val isEc: Boolean = false) :
     Asn1Encodable<Asn1Sequence>, Identifiable {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/X509SignatureAlgorithm.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/X509SignatureAlgorithm.kt
@@ -13,8 +13,10 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = X509SignatureAlgorithmSerializer::class)
-enum class X509SignatureAlgorithm(override val oid: ObjectIdentifier, val isEc: Boolean = false) :
-    Asn1Encodable<Asn1Sequence>, Identifiable {
+enum class X509SignatureAlgorithm(
+    override val oid: ObjectIdentifier,
+    val isEc: Boolean = false
+) : Asn1Encodable<Asn1Sequence>, Identifiable {
 
     // ECDSA with SHA-size
     ES256(KnownOIDs.ecdsaWithSHA256, true),

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/X509SignatureAlgorithm.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/X509SignatureAlgorithm.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes
 
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.asn1.*
 import at.asitplus.crypto.datatypes.asn1.Asn1.Null
 import at.asitplus.crypto.datatypes.asn1.Asn1.Tagged
@@ -21,8 +22,8 @@ import kotlinx.serialization.encoding.Encoder
 val OID_ECDH_ES = ObjectIdentifier("1.3.132.1.12")
 
 @Serializable(with = X509SignatureAlgorithmSerializer::class)
-enum class X509SignatureAlgorithm(override val oid: ObjectIdentifier, val isEc: Boolean = false)
-    : Asn1Encodable<Asn1Sequence>, Identifiable {
+enum class X509SignatureAlgorithm(override val oid: ObjectIdentifier, val isEc: Boolean = false) :
+    Asn1Encodable<Asn1Sequence>, Identifiable {
 
     // ECDSA with SHA-size
     ES256(KnownOIDs.ecdsaWithSHA256, true),
@@ -98,7 +99,7 @@ enum class X509SignatureAlgorithm(override val oid: ObjectIdentifier, val isEc: 
     companion object : Asn1Decodable<Asn1Sequence, X509SignatureAlgorithm> {
 
         @Throws(Asn1OidException::class)
-        private fun fromOid(oid: ObjectIdentifier) = runCatching { entries.first { it.oid == oid } }.getOrElse {
+        private fun fromOid(oid: ObjectIdentifier) = catching { entries.first { it.oid == oid } }.getOrElse {
             throw Asn1OidException("Unsupported OID: $oid", oid)
         }
 
@@ -157,8 +158,10 @@ enum class X509SignatureAlgorithm(override val oid: ObjectIdentifier, val isEc: 
     }
 }
 
-@Deprecated("Will likely be replaced with a more general type in the future",
-    replaceWith = ReplaceWith("X509SignatureAlgorithm"))
+@Deprecated(
+    "Will likely be replaced with a more general type in the future",
+    replaceWith = ReplaceWith("X509SignatureAlgorithm")
+)
 typealias CryptoAlgorithm = X509SignatureAlgorithm
 
 object X509SignatureAlgorithmSerializer : KSerializer<X509SignatureAlgorithm> {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Decoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Decoding.kt
@@ -53,7 +53,7 @@ private class Asn1Reader(input: ByteArray) {
                 )
             )
             else if (tlv.tag == OCTET_STRING) {
-                runCatching {
+                catching {
                     result.add(Asn1EncapsulatingOctetString(Asn1Reader(tlv.content).doParse()))
                 }.getOrElse { result.add(Asn1PrimitiveOctetString(tlv.content)) }
             } else result.add(Asn1Primitive(tlv.tag, tlv.content))
@@ -156,7 +156,7 @@ fun Asn1Primitive.readString(): Asn1String = runRethrowing {
 /**
  * Exception-free version of [readString]
  */
-fun Asn1Primitive.readStringOrNull() = runCatching { readString() }.getOrNull()
+fun Asn1Primitive.readStringOrNull() = catching { readString() }.getOrNull()
 
 
 /**
@@ -173,7 +173,7 @@ fun Asn1Primitive.readInstant() =
 /**
  * Exception-free version of [readInstant]
  */
-fun Asn1Primitive.readInstantOrNull() = runCatching { readInstant() }.getOrNull()
+fun Asn1Primitive.readInstantOrNull() = catching { readInstant() }.getOrNull()
 
 
 /**
@@ -187,7 +187,7 @@ fun Asn1Primitive.readBitString() = Asn1BitString.decodeFromTlv(this)
 /**
  * Exception-free version of [readBitString]
  */
-fun Asn1Primitive.readBitStringOrNull() = runCatching { readBitString() }.getOrNull()
+fun Asn1Primitive.readBitStringOrNull() = catching { readBitString() }.getOrNull()
 
 
 /**
@@ -201,7 +201,7 @@ fun Asn1Primitive.readNull() = decode(ASN1_NULL) {}
 /**
  * Name seems odd, but this is just an exception-free version of [readNull]
  */
-fun Asn1Primitive.readNullOrNull() = runCatching { readNull() }.getOrNull()
+fun Asn1Primitive.readNullOrNull() = catching { readNull() }.getOrNull()
 
 
 /**
@@ -218,7 +218,7 @@ fun Asn1Tagged.verifyTag(tag: UByte): List<Asn1Element> {
 /**
  * Exception-free version of [verifyTag]
  */
-fun Asn1Tagged.verifyTagOrNull(tag: UByte) = runCatching { verifyTag(tag) }.getOrNull()
+fun Asn1Tagged.verifyTagOrNull(tag: UByte) = catching { verifyTag(tag) }.getOrNull()
 
 
 /**
@@ -236,7 +236,7 @@ inline fun <reified T> Asn1Primitive.decode(tag: UByte, transform: (content: Byt
  * Exception-free version of [decode]
  */
 inline fun <reified T> Asn1Primitive.decodeOrNull(tag: UByte, transform: (content: ByteArray) -> T) =
-    runCatching { decode(tag, transform) }.getOrNull()
+    catching { decode(tag, transform) }.getOrNull()
 
 @Throws(Asn1Exception::class)
 private fun Instant.Companion.decodeUtcTimeFromDer(input: ByteArray): Instant = runRethrowing {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Decoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Decoding.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.asn1
 
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.asn1.BERTags.ASN1_NULL
 import at.asitplus.crypto.datatypes.asn1.BERTags.BMP_STRING
 import at.asitplus.crypto.datatypes.asn1.BERTags.BOOLEAN
@@ -111,12 +112,13 @@ fun Asn1Primitive.readBigInteger() =
 /**
  * Exception-free version of [readBigInteger]
  */
-inline fun Asn1Primitive.readBigIntegerOrNull() = runCatching { readBigInteger() }.getOrNull()
+@Suppress("NOTHING_TO_INLINE")
+inline fun Asn1Primitive.readBigIntegerOrNull() = catching { readBigInteger() }.getOrNull()
 
 /**
  * Exception-free version of [readInt]
  */
-fun Asn1Primitive.readIntOrNull() = runCatching { readInt() }.getOrNull()
+fun Asn1Primitive.readIntOrNull() = catching { readInt() }.getOrNull()
 
 
 /**
@@ -130,7 +132,7 @@ fun Asn1Primitive.readLong() = runRethrowing { decode(INTEGER) { Long.decodeFrom
 /**
  * Exception-free version of [readLong]
  */
-fun Asn1Primitive.readLongOrNull() = runCatching { readLong() }.getOrNull()
+fun Asn1Primitive.readLongOrNull() = catching { readLong() }.getOrNull()
 
 
 /**

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Elements.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.asn1
 
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.asn1.DERTags.isExplicitTag
 import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
@@ -155,12 +156,12 @@ sealed class Asn1Structure(tag: UByte, children: List<Asn1Element>?) :
      */
     @Throws(Asn1StructuralException::class)
     fun nextChild() =
-        runCatching { children[index++] }.getOrElse { throw Asn1StructuralException("No more content left") }
+        catching { children[index++] }.getOrElse { throw Asn1StructuralException("No more content left") }
 
     /**
      * Exception-free version of [nextChild]
      */
-    fun nextChildOrNull() = runCatching { nextChild() }.getOrNull()
+    fun nextChildOrNull() = catching { nextChild() }.getOrNull()
 
     /**
      * Returns `true` if more children can be retrieved by [nextChild]. `false` otherwise
@@ -210,6 +211,7 @@ class Asn1Sequence internal constructor(children: List<Asn1Element>) : Asn1Struc
  * ASN.1 OCTET STRING 0x04 ([BERTags.OCTET_STRING]) containing an [Asn1Element]
  * @param children the elements to put into this sequence
  */
+@Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
 @Serializable(with = Asn1EncodableSerializer::class)
 class Asn1EncapsulatingOctetString(children: List<Asn1Element>) : Asn1Structure(BERTags.OCTET_STRING, children),
     Asn1OctetString<Asn1EncapsulatingOctetString> {

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encodable.kt
@@ -4,6 +4,7 @@ package at.asitplus.crypto.datatypes.asn1
 
 import at.asitplus.KmmResult
 import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.asn1.DERTags.toImplicitTag
 
 /**
@@ -21,12 +22,12 @@ interface Asn1Encodable<A : Asn1Element> {
     /**
      * Exception-free version of [encodeToTlv]
      */
-    fun encodeToTlvOrNull() = runCatching { encodeToTlv() }.getOrNull()
+    fun encodeToTlvOrNull() = catching { encodeToTlv() }.getOrNull()
 
     /**
      * Safe version of [encodeToTlv], wrapping the result into a [KmmResult]
      */
-    fun encodeToTlvSafe() = kotlin.runCatching { encodeToTlv() }.wrap()
+    fun encodeToTlvSafe() = catching { encodeToTlv() }
 
     /**
      * Convenience function to directly get the DER-encoded representation of the implementing object
@@ -37,12 +38,12 @@ interface Asn1Encodable<A : Asn1Element> {
     /**
      * Exception-free version of [encodeToDer]
      */
-    fun encodeToDerOrNull() = runCatching { encodeToDer() }.getOrNull()
+    fun encodeToDerOrNull() = catching { encodeToDer() }.getOrNull()
 
     /**
      * Safe version of [encodeToDer], wrapping the result into a [KmmResult]
      */
-    fun encodeToDerSafe() = kotlin.runCatching { encodeToDer() }.wrap()
+    fun encodeToDerSafe() = catching { encodeToDer() }
 }
 
 /**
@@ -60,12 +61,12 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
     /**
      * Exception-free version of [decodeFromTlv]
      */
-    fun decodeFromTlvOrNull(src: A) = runCatching { decodeFromTlv(src) }.getOrNull()
+    fun decodeFromTlvOrNull(src: A) = catching { decodeFromTlv(src) }.getOrNull()
 
     /**
      * Safe version of [decodeFromTlv], wrapping the result into a [KmmResult]
      */
-    fun decodeFromTlvSafe(src: A) = kotlin.runCatching { decodeFromTlv(src) }.wrap()
+    fun decodeFromTlvSafe(src: A) = catching { decodeFromTlv(src) }
 
     /**
      * Convenience method, directly DER-decoding a byte array to [T]
@@ -77,12 +78,12 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
     /**
      * Exception-free version of [decodeFromDer]
      */
-    fun decodeFromDerOrNull(src: ByteArray) = runCatching { decodeFromDer(src) }.getOrNull()
+    fun decodeFromDerOrNull(src: ByteArray) = catching { decodeFromDer(src) }.getOrNull()
 
     /**
      * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
      */
-    fun decodeFromDerSafe(src: ByteArray) = runCatching { decodeFromDer(src) }.wrap()
+    fun decodeFromDerSafe(src: ByteArray) = catching { decodeFromDer(src) }
 }
 
 interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
@@ -100,13 +101,13 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
      * Exception-free version of [decodeFromTlv]
      */
     fun decodeFromTlvOrNull(src: Asn1Primitive, tagOverride: UByte?) =
-        runCatching { decodeFromTlv(src, tagOverride) }.getOrNull()
+        catching { decodeFromTlv(src, tagOverride) }.getOrNull()
 
     /**
      * Safe version of [decodeFromTlv], wrapping the result into a [KmmResult]
      */
     fun decodeFromTlvSafe(src: Asn1Primitive, tagOverride: UByte?) =
-        kotlin.runCatching { decodeFromTlv(src, tagOverride) }.wrap()
+        catching { decodeFromTlv(src, tagOverride) }
 
 
     /**
@@ -121,10 +122,10 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
      * Exception-free version of [decodeFromDer]
      */
     fun decodeFromDerOrNull(src: ByteArray, tagOverride: UByte?) =
-        runCatching { decodeFromDer(src, tagOverride) }.getOrNull()
+        catching { decodeFromDer(src, tagOverride) }.getOrNull()
 
     /**
      * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
      */
-    fun decodeFromDerSafe(src: ByteArray, tagOverride: UByte?)= runCatching { decodeFromDer(src, tagOverride) }.wrap()
+    fun decodeFromDerSafe(src: ByteArray, tagOverride: UByte?) = catching { decodeFromDer(src, tagOverride) }
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
@@ -2,6 +2,7 @@ package at.asitplus.crypto.datatypes.asn1
 
 import at.asitplus.KmmResult
 import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.asn1.BERTags.ASN1_NULL
 import at.asitplus.crypto.datatypes.asn1.BERTags.BIT_STRING
 import at.asitplus.crypto.datatypes.asn1.BERTags.BOOLEAN
@@ -104,13 +105,13 @@ object Asn1 {
      * Exception-free version of [Sequence]
      */
     fun SequenceOrNull(root: Asn1TreeBuilder.() -> Unit) =
-        runCatching { Sequence(root) }.getOrNull()
+        catching { Sequence(root) }.getOrNull()
 
 
     /**
      * Safe version of [Sequence], wrapping the result into a [KmmResult]
      */
-    fun SequenceSafe(root: Asn1TreeBuilder.() -> Unit) = runCatching { Sequence(root) }.wrap()
+    fun SequenceSafe(root: Asn1TreeBuilder.() -> Unit) = catching { Sequence(root) }
 
 
     /**
@@ -135,13 +136,13 @@ object Asn1 {
     /**
      * Exception-free version of [Set]
      */
-    fun SetOrNull(root: Asn1TreeBuilder.() -> Unit) = runCatching { Set(root) }.getOrNull()
+    fun SetOrNull(root: Asn1TreeBuilder.() -> Unit) = catching { Set(root) }.getOrNull()
 
 
     /**
      * Safe version of [Set], wrapping the result into a [KmmResult]
      */
-    fun SetSafe(root: Asn1TreeBuilder.() -> Unit) = runCatching { Set(root) }.wrap()
+    fun SetSafe(root: Asn1TreeBuilder.() -> Unit) = catching { Set(root) }
 
 
     /**
@@ -168,13 +169,13 @@ object Asn1 {
     /**
      * Exception-free version of [SetOf]
      */
-    fun SetOfOrNull(root: Asn1TreeBuilder.() -> Unit) = runCatching { SetOf(root) }.getOrNull()
+    fun SetOfOrNull(root: Asn1TreeBuilder.() -> Unit) = catching { SetOf(root) }.getOrNull()
 
 
     /**
      * Safe version of [SetOf], wrapping the result into a [KmmResult]
      */
-    fun SetOfSafe(root: Asn1TreeBuilder.() -> Unit) = runCatching { SetOf(root) }.wrap()
+    fun SetOfSafe(root: Asn1TreeBuilder.() -> Unit) = catching { SetOf(root) }
 
 
     /**
@@ -202,14 +203,13 @@ object Asn1 {
      * Exception-free version of [Tagged]
      */
     fun TaggedOrNull(tag: UByte, root: Asn1TreeBuilder.() -> Unit) =
-        runCatching { Tagged(tag, root) }.getOrNull()
+        catching { Tagged(tag, root) }.getOrNull()
 
     /**
      * Safe version on [Tagged], wrapping the result into a [KmmResult]
      */
     fun TaggedSafe(tag: UByte, root: Asn1TreeBuilder.() -> Unit) =
-        runCatching { Tagged(tag, root) }.wrap()
-
+        catching { Tagged(tag, root) }
 
 
     /**
@@ -509,11 +509,13 @@ fun Int.encodeToByteArray(): ByteArray {
 /**
  * Drops or adds zero bytes at the start until the [size] is reached
  */
-fun ByteArray.ensureSize(size: Int): ByteArray = (this.size-size).let { toDrop -> when {
-    toDrop > 0 -> this.copyOfRange(toDrop, this.size)
-    toDrop < 0 -> ByteArray(-toDrop) + this
-    else -> this
-} }
+fun ByteArray.ensureSize(size: Int): ByteArray = (this.size - size).let { toDrop ->
+    when {
+        toDrop > 0 -> this.copyOfRange(toDrop, this.size)
+        toDrop < 0 -> ByteArray(-toDrop) + this
+        else -> this
+    }
+}
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun ByteArray.ensureSize(size: UInt) = ensureSize(size.toInt())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Encoding.kt
@@ -514,4 +514,6 @@ fun ByteArray.ensureSize(size: Int): ByteArray = (this.size-size).let { toDrop -
     toDrop < 0 -> ByteArray(-toDrop) + this
     else -> this
 } }
+
+@Suppress("NOTHING_TO_INLINE")
 inline fun ByteArray.ensureSize(size: UInt) = ensureSize(size.toInt())

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
@@ -15,7 +15,7 @@ class Asn1StructuralException(message: String) : Asn1Exception(message)
 class Asn1OidException(message: String, val oid: ObjectIdentifier) : Asn1Exception(message)
 
 /**
- * Runs [block] inside [runCatching] and encapsulates any thrown exception in an [Asn1Exception] unless it already is one
+ * Runs [block] inside [catching] and encapsulates any thrown exception in an [Asn1Exception] unless it already is one
  */
 @Throws(Asn1Exception::class)
 inline fun <reified R> runRethrowing(block: () -> R) =

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
@@ -1,5 +1,7 @@
 package at.asitplus.crypto.datatypes.asn1
 
+import at.asitplus.catching
+
 open class Asn1Exception(message: String?, cause: Throwable?) : Throwable(message, cause) {
     constructor(message: String) : this(message, null)
     constructor(throwable: Throwable) : this(null, throwable)
@@ -17,4 +19,4 @@ class Asn1OidException(message: String, val oid: ObjectIdentifier) : Asn1Excepti
  */
 @Throws(Asn1Exception::class)
 inline fun <reified R> runRethrowing(block: () -> R) =
-    runCatching(block).getOrElse { throw if (it is Asn1Exception) it else Asn1Exception(it.message, it) }
+    catching(block).getOrElse { throw if (it is Asn1Exception) it else Asn1Exception(it.message, it) }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Exception.kt
@@ -1,6 +1,7 @@
 package at.asitplus.crypto.datatypes.asn1
 
 import at.asitplus.catching
+import at.asitplus.wrapping
 
 open class Asn1Exception(message: String?, cause: Throwable?) : Throwable(message, cause) {
     constructor(message: String) : this(message, null)
@@ -18,5 +19,4 @@ class Asn1OidException(message: String, val oid: ObjectIdentifier) : Asn1Excepti
  * Runs [block] inside [catching] and encapsulates any thrown exception in an [Asn1Exception] unless it already is one
  */
 @Throws(Asn1Exception::class)
-inline fun <reified R> runRethrowing(block: () -> R) =
-    catching(block).getOrElse { throw if (it is Asn1Exception) it else Asn1Exception(it.message, it) }
+inline fun <reified R> runRethrowing(block: () -> R) = wrapping(asA = ::Asn1Exception, block).getOrThrow()

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/Asn1Time.kt
@@ -22,7 +22,8 @@ class Asn1Time(instant: Instant, formatOverride: Format? = null) : Asn1Encodable
     /**
      * Indicates whether this timestamp uses UTC TIME or GENERALIZED TIME
      */
-    val format: Format =  formatOverride ?: if (this.instant > THRESHOLD_GENERALIZED_TIME) Format.GENERALIZED else Format.UTC
+    val format: Format =
+        formatOverride ?: if (this.instant > THRESHOLD_GENERALIZED_TIME) Format.GENERALIZED else Format.UTC
 
     companion object : Asn1Decodable<Asn1Primitive, Asn1Time> {
         private val THRESHOLD_GENERALIZED_TIME = Instant.parse("2050-01-01T00:00:00Z")

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/ObjectIdentifier.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/ObjectIdentifier.kt
@@ -179,20 +179,26 @@ private fun ByteArray.toSeptets(): ByteArray {
     return chunks.toByteArray()
 }
 
+@Suppress("NOTHING_TO_INLINE")
 private inline fun ByteArray.getBit(index: Int): Boolean =
     if (index < 0) throw IndexOutOfBoundsException("index = $index")
     else kotlin.runCatching {
         this[getByteIndex(index)].getBit(getBitIndex(index))
     }.getOrElse { false }
 
+@Suppress("NOTHING_TO_INLINE")
 private inline fun ByteArray.setBit(i: Int) {
     this[getByteIndex(i)] = this[getByteIndex(i)].setBit(getBitIndex(i))
 }
 
+@Suppress("NOTHING_TO_INLINE")
 private inline fun Byte.setBit(i: Int) = ((1 shl getBitIndex(i)).toByte() or this)
+@Suppress("NOTHING_TO_INLINE")
 private inline fun getByteIndex(i: Int) = (i / 8)
+@Suppress("NOTHING_TO_INLINE")
 private inline fun getBitIndex(i: Int) = (i % 8)
 
+@Suppress("NOTHING_TO_INLINE")
 private inline fun Byte.getBit(index: Int): Boolean = (((1 shl index).toByte() and this) != 0.toByte())
 
 private fun UInt.toCompactByteArray(): ByteArray =

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/ObjectIdentifier.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/asn1/ObjectIdentifier.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.asn1
 
+import at.asitplus.catching
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -182,7 +183,7 @@ private fun ByteArray.toSeptets(): ByteArray {
 @Suppress("NOTHING_TO_INLINE")
 private inline fun ByteArray.getBit(index: Int): Boolean =
     if (index < 0) throw IndexOutOfBoundsException("index = $index")
-    else kotlin.runCatching {
+    else catching {
         this[getByteIndex(index)].getBit(getBitIndex(index))
     }.getOrElse { false }
 
@@ -193,8 +194,10 @@ private inline fun ByteArray.setBit(i: Int) {
 
 @Suppress("NOTHING_TO_INLINE")
 private inline fun Byte.setBit(i: Int) = ((1 shl getBitIndex(i)).toByte() or this)
+
 @Suppress("NOTHING_TO_INLINE")
 private inline fun getByteIndex(i: Int) = (i / 8)
+
 @Suppress("NOTHING_TO_INLINE")
 private inline fun getBitIndex(i: Int) = (i % 8)
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/BaseN.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/BaseN.kt
@@ -31,8 +31,6 @@ import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 
 
-
-
 /**
  * changjiashuai@gmail.com.
  *

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/BitSet.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/BitSet.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.io
 
+import at.asitplus.catching
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -15,7 +16,7 @@ private fun getBitIndex(i: Long) = (i % 8).toInt()
 
 private fun List<Byte>.getBit(index: Long): Boolean =
     if (index < 0) throw IndexOutOfBoundsException("index = $index")
-    else kotlin.runCatching {
+    else catching {
         this[getByteIndex(index)].getBit(getBitIndex(index))
     }.getOrElse { false }
 
@@ -243,7 +244,7 @@ class BitSet private constructor(private val buffer: MutableList<Byte>) : Iterab
         /**
          * Exception-free version of [fromBitString]
          */
-        fun fromBitStringOrNull(bitString: String) = runCatching { fromBitString(bitString) }.getOrNull()
+        fun fromBitStringOrNull(bitString: String) = catching { fromBitString(bitString) }.getOrNull()
     }
 }
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/Encoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/Encoding.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.io
 
+import at.asitplus.catching
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.base64.Base64ConfigBuilder
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
@@ -50,7 +51,7 @@ object ByteArrayBase64Serializer : KSerializer<ByteArray> {
      * @throws SerializationException on error
      */
     override fun deserialize(decoder: Decoder): ByteArray {
-        return kotlin.runCatching { decoder.decodeString().decodeToByteArray(Base64Strict) }
+        return catching { decoder.decodeString().decodeToByteArray(Base64Strict) }
             .getOrElse { throw SerializationException("Base64 decoding failed", it) }
     }
 
@@ -74,7 +75,7 @@ object ByteArrayBase64UrlSerializer : KSerializer<ByteArray> {
      * @throws SerializationException on error
      */
     override fun deserialize(decoder: Decoder): ByteArray {
-        return kotlin.runCatching { decoder.decodeString().decodeToByteArray(Base64UrlStrict) }
+        return catching { decoder.decodeString().decodeToByteArray(Base64UrlStrict) }
             .getOrElse { throw SerializationException("Base64 decoding failed", it) }
     }
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/Encoding.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/io/Encoding.kt
@@ -74,8 +74,8 @@ object ByteArrayBase64UrlSerializer : KSerializer<ByteArray> {
     /**
      * @throws SerializationException on error
      */
-    override fun deserialize(decoder: Decoder): ByteArray {
-        return catching { decoder.decodeString().decodeToByteArray(Base64UrlStrict) }
+    override fun deserialize(decoder: Decoder): ByteArray =
+        catching { decoder.decodeString().decodeToByteArray(Base64UrlStrict) }
             .getOrElse { throw SerializationException("Base64 decoding failed", it) }
-    }
+
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/BitLength.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/BitLength.kt
@@ -3,22 +3,29 @@ package at.asitplus.crypto.datatypes.misc
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import kotlin.jvm.JvmInline
 
-@JvmInline
-value class BitLength (val bits: UInt): Comparable<BitLength> {
+/**
+ * Utility class to represent the bit length of curves and signatures.
+ *
+ * Should be a value class, but the Swift export becomes impossible.
+ */
+data class BitLength (val bits: UInt): Comparable<BitLength> {
     inline val bytes: UInt get() =
         bits.floorDiv(8u) + (if(bits.rem(8u) != 0u) 1u else 0u)
 
     companion object {
+        @Suppress("NOTHING_TO_INLINE")
         inline fun of(v: BigInteger) = BitLength(v.bitLength().toUInt())
     }
 
-    inline override fun compareTo(other: BitLength): Int =
+    @Suppress("NOTHING_TO_INLINE", "OVERRIDE_BY_INLINE")
+    override inline fun compareTo(other: BitLength): Int =
         bits.compareTo(other.bits)
-
 }
 
+@Suppress("NOTHING_TO_INLINE")
 inline fun min(a: BitLength, b: BitLength) =
     if (a.bits < b.bits) a else b
 
+@Suppress("NOTHING_TO_INLINE")
 inline fun max(a: BitLength, b: BitLength) =
     if (a.bits < b.bits) b else a

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/BitLength.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/BitLength.kt
@@ -8,9 +8,10 @@ import kotlin.jvm.JvmInline
  *
  * Should be a value class, but the Swift export becomes impossible.
  */
-data class BitLength (val bits: UInt): Comparable<BitLength> {
-    inline val bytes: UInt get() =
-        bits.floorDiv(8u) + (if(bits.rem(8u) != 0u) 1u else 0u)
+data class BitLength(val bits: UInt) : Comparable<BitLength> {
+    inline val bytes: UInt
+        get() =
+            bits.floorDiv(8u) + (if (bits.rem(8u) != 0u) 1u else 0u)
 
     companion object {
         @Suppress("NOTHING_TO_INLINE")

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/PointCompression.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/PointCompression.kt
@@ -25,8 +25,8 @@ enum class ANSIECPrefix(val prefixByte: Byte) {
     companion object {
 
         /**
-         * Gets the ANSI prefix for [byte].
-         * @throws IllegalArgumentException for ZERO
+         * Gets the [ANSIECPrefix] for [byte].
+         * @throws IllegalArgumentException for bytes that don't map to a valid prefix
          */
         @Suppress("NOTHING_TO_INLINE")
         inline fun fromPrefixByte(byte: Byte) = when (byte) {
@@ -37,8 +37,8 @@ enum class ANSIECPrefix(val prefixByte: Byte) {
         }
 
         /**
-         * Gets the ANSI prefix for [sign].
-         * @throws IllegalArgumentException for ZERO
+         * Gets the [ANSIECPrefix] for [sign].
+         * @throws IllegalArgumentException for [Sign.ZERO]
          */
         @Suppress("NOTHING_TO_INLINE")
         inline fun forSign(sign: Sign) = when (sign) {
@@ -82,9 +82,9 @@ internal fun decompressY(curve: ECCurve, x: ModularBigInteger, sign: Sign): Modu
     val alpha = x.pow(3) + curve.a * x + curve.b
 
     require(quadraticResidueTest(alpha))
-    { "Invalid compressed point (x=$x) on $curve" }
+        { "Invalid compressed point (x=$x) on $curve" }
     require(curve.modulus.bitAt(0) && curve.modulus.bitAt(1)) // (modulus % 4) == 3
-    { "Decompression on $curve requires Tonelli-Shanks Algorithm" }
+        { "Decompression on $curve requires Tonelli-Shanks Algorithm" }
 
 
     val beta = alpha.pow((curve.modulus + 1) / 4)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/PointCompression.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/PointCompression.kt
@@ -18,9 +18,16 @@ enum class ANSIECPrefix(val prefixByte: Byte) {
     }
     val prefixUByte inline get() = prefixByte.toUByte()
 
+    @Suppress("NOTHING_TO_INLINE")
     inline operator fun plus(that: ByteArray) = byteArrayOf(prefixByte, *that)
 
     companion object {
+
+        /**
+         * Gets the ANSI prefix for [byte].
+         * @throws IllegalArgumentException for ZERO
+         */
+        @Suppress("NOTHING_TO_INLINE")
         inline fun fromPrefixByte(byte: Byte) = when (byte) {
             COMPRESSED_MINUS.prefixByte -> COMPRESSED_MINUS
             COMPRESSED_PLUS.prefixByte -> COMPRESSED_PLUS
@@ -28,12 +35,18 @@ enum class ANSIECPrefix(val prefixByte: Byte) {
             else -> throw IllegalArgumentException("invalid prefix $byte")
         }
 
+        /**
+         * Gets the ANSI prefix for [sign].
+         * @throws IllegalArgumentException for ZERO
+         */
+        @Suppress("NOTHING_TO_INLINE")
         inline fun forSign(sign: Sign) = when (sign) {
             Sign.NEGATIVE -> COMPRESSED_MINUS
             Sign.POSITIVE -> COMPRESSED_PLUS
             Sign.ZERO -> throw IllegalArgumentException("Sign.ZERO")
         }
 
+        @Suppress("NOTHING_TO_INLINE")
         inline fun ByteArray.hasPrefix(prefix: ANSIECPrefix) = (first() == prefix.prefixByte)
     }
 }

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/PointCompression.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/misc/PointCompression.kt
@@ -11,11 +11,12 @@ enum class ANSIECPrefix(val prefixByte: Byte) {
 
     val isUncompressed inline get() = (this == UNCOMPRESSED)
     val isCompressed inline get() = !isUncompressed
-    val compressionSign inline get() = when (this) {
-        COMPRESSED_MINUS -> Sign.NEGATIVE
-        COMPRESSED_PLUS -> Sign.POSITIVE
-        UNCOMPRESSED -> throw IllegalStateException("not compressed")
-    }
+    val compressionSign
+        inline get() = when (this) {
+            COMPRESSED_MINUS -> Sign.NEGATIVE
+            COMPRESSED_PLUS -> Sign.POSITIVE
+            UNCOMPRESSED -> throw IllegalStateException("not compressed")
+        }
     val prefixUByte inline get() = prefixByte.toUByte()
 
     @Suppress("NOTHING_TO_INLINE")
@@ -81,9 +82,9 @@ internal fun decompressY(curve: ECCurve, x: ModularBigInteger, sign: Sign): Modu
     val alpha = x.pow(3) + curve.a * x + curve.b
 
     require(quadraticResidueTest(alpha))
-        { "Invalid compressed point (x=$x) on $curve"}
+    { "Invalid compressed point (x=$x) on $curve" }
     require(curve.modulus.bitAt(0) && curve.modulus.bitAt(1)) // (modulus % 4) == 3
-        { "Decompression on $curve requires Tonelli-Shanks Algorithm" }
+    { "Decompression on $curve requires Tonelli-Shanks Algorithm" }
 
 
     val beta = alpha.pow((curve.modulus + 1) / 4)

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/RelativeDistinguishedName.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/RelativeDistinguishedName.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.pki
 
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.asn1.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -122,7 +123,7 @@ sealed class AttributeTypeAndValue : Asn1Encodable<Asn1Sequence>, Identifiable {
             val oid = (src.nextChild() as Asn1Primitive).readOid()
             if (oid.nodes.size >= 3 && oid.toString().startsWith("2.5.4.")) {
                 val asn1String = src.nextChild() as Asn1Primitive
-                val str = runCatching { (asn1String).readString() }
+                val str = catching { (asn1String).readString() }
                 if (src.hasMoreChildren()) throw Asn1StructuralException("Superfluous elements in RDN")
                 return when (oid) {
                     CommonName.OID -> str.fold(onSuccess = { CommonName(it) }, onFailure = { CommonName(asn1String) })

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/datatypes/pki/X509Certificate.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes.pki
 
+import at.asitplus.catching
 import at.asitplus.crypto.datatypes.X509SignatureAlgorithm
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.CryptoSignature
@@ -261,11 +262,11 @@ data class X509Certificate @Throws(IllegalArgumentException::class) constructor(
          * or by decoding from Base64, or by decoding to a String, stripping PEM headers
          * (`-----BEGIN CERTIFICATE-----`) and then decoding from Base64.
          */
-        fun decodeFromByteArray(src: ByteArray): X509Certificate? = runCatching {
+        fun decodeFromByteArray(src: ByteArray): X509Certificate? = catching {
             X509Certificate.decodeFromTlv(Asn1Element.parse(src) as Asn1Sequence)
-        }.getOrNull() ?: runCatching {
+        }.getOrNull() ?: catching {
             X509Certificate.decodeFromTlv(Asn1Element.parse(src.decodeToByteArray(Base64())) as Asn1Sequence)
-        }.getOrNull() ?: runCatching {
+        }.getOrNull() ?: catching {
             X509Certificate.decodeFromTlv(Asn1Element.parse(src.decodeX5c()) as Asn1Sequence)
         }.getOrNull()
 

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/ecmath/ECMath.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/ecmath/ECMath.kt
@@ -122,15 +122,17 @@ fun ECPoint.double(): ECPoint {
 
 @Suppress("NOTHING_TO_INLINE")
 inline operator fun ECPoint.unaryPlus() = this
+
 @Suppress("NOTHING_TO_INLINE")
 inline operator fun ECPoint.unaryMinus() =
     ECPoint.General.unsafeFromXYZ(curve, homX, -homY, homZ)
+
 @Suppress("NOTHING_TO_INLINE")
 inline operator fun ECPoint.Normalized.unaryMinus() =
     ECPoint.Normalized.unsafeFromXY(curve, x, -y)
 
 @Suppress("NOTHING_TO_INLINE")
-inline operator fun ECPoint.minus(other: ECPoint) = this+(-other)
+inline operator fun ECPoint.minus(other: ECPoint) = this + (-other)
 
 // TODO: i'm sure this could be smarter (keyword: "comb")
 // i'm also sure this isn't resistant to timing side channels if that is something you care about
@@ -150,12 +152,15 @@ operator fun BigInteger.times(point: ECPoint): ECPoint {
 @Suppress("NOTHING_TO_INLINE")
 inline operator fun Int.times(point: ECPoint) =
     BigInteger.fromInt(this).times(point)
+
 @Suppress("NOTHING_TO_INLINE")
 inline operator fun Long.times(point: ECPoint) =
     BigInteger.fromLong(this).times(point)
+
 @Suppress("NOTHING_TO_INLINE")
 inline operator fun UInt.times(point: ECPoint) =
     BigInteger.fromUInt(this).times(point)
+
 @Suppress("NOTHING_TO_INLINE")
 inline operator fun ULong.times(point: ECPoint) =
     BigInteger.fromULong(this).times(point)
@@ -169,13 +174,18 @@ inline operator fun ModularBigInteger.times(point: ECPoint): ECPoint {
 /* these are intentionally not operator functions! */
 @Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: BigInteger) = v * this
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: ModularBigInteger) = v * this
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: Int) = v * this
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: UInt) = v * this
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: Long) = v * this
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: ULong) = v * this

--- a/datatypes/src/commonMain/kotlin/at/asitplus/crypto/ecmath/ECMath.kt
+++ b/datatypes/src/commonMain/kotlin/at/asitplus/crypto/ecmath/ECMath.kt
@@ -120,12 +120,16 @@ fun ECPoint.double(): ECPoint {
     return ECPoint.General.unsafeFromXYZ(curve, X3, Y3, Z3)
 }
 
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun ECPoint.unaryPlus() = this
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun ECPoint.unaryMinus() =
     ECPoint.General.unsafeFromXYZ(curve, homX, -homY, homZ)
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun ECPoint.Normalized.unaryMinus() =
     ECPoint.Normalized.unsafeFromXY(curve, x, -y)
 
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun ECPoint.minus(other: ECPoint) = this+(-other)
 
 // TODO: i'm sure this could be smarter (keyword: "comb")
@@ -143,24 +147,35 @@ operator fun BigInteger.times(point: ECPoint): ECPoint {
     return sum
 }
 
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun Int.times(point: ECPoint) =
     BigInteger.fromInt(this).times(point)
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun Long.times(point: ECPoint) =
     BigInteger.fromLong(this).times(point)
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun UInt.times(point: ECPoint) =
     BigInteger.fromUInt(this).times(point)
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun ULong.times(point: ECPoint) =
     BigInteger.fromULong(this).times(point)
 
+@Suppress("NOTHING_TO_INLINE")
 inline operator fun ModularBigInteger.times(point: ECPoint): ECPoint {
     require(this.modulus == point.curve.order)
     return this.residue.times(point)
 }
 
 /* these are intentionally not operator functions! */
+@Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: BigInteger) = v * this
+@Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: ModularBigInteger) = v * this
+@Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: Int) = v * this
+@Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: UInt) = v * this
+@Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: Long) = v * this
+@Suppress("NOTHING_TO_INLINE")
 inline fun ECPoint.times(v: ULong) = v * this

--- a/datatypes/src/iosTest/kotlin/Test.kt
+++ b/datatypes/src/iosTest/kotlin/Test.kt
@@ -1,9 +1,9 @@
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldNotBe
 
-class Test: FreeSpec( {
+class Test : FreeSpec({
 
     "This dummy test" {
-       "is just making shure" shouldNotBe "that iOS tests are indeed running"
+        "is just making sure" shouldNotBe "that iOS tests are indeed running"
     }
 })

--- a/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
+++ b/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
@@ -137,7 +137,10 @@ val CryptoSignature.jcaSignatureBytes: ByteArray
 /**
  * In Java EC signatures are returned as DER-encoded, RSA signatures however are raw bytearrays
  */
-fun CryptoSignature.Companion.parseFromJca(input: ByteArray, algorithm: X509SignatureAlgorithm) :CryptoSignature.Defined =
+fun CryptoSignature.Companion.parseFromJca(
+    input: ByteArray,
+    algorithm: X509SignatureAlgorithm
+): CryptoSignature.Defined =
     if (algorithm.isEc)
         CryptoSignature.EC.decodeFromDer(input)
     else

--- a/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
+++ b/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
@@ -137,7 +137,7 @@ val CryptoSignature.jcaSignatureBytes: ByteArray
 /**
  * In Java EC signatures are returned as DER-encoded, RSA signatures however are raw bytearrays
  */
-fun CryptoSignature.Companion.parseFromJca(input: ByteArray, algorithm: X509SignatureAlgorithm) =
+fun CryptoSignature.Companion.parseFromJca(input: ByteArray, algorithm: X509SignatureAlgorithm) :CryptoSignature.Defined =
     if (algorithm.isEc)
         CryptoSignature.EC.decodeFromDer(input)
     else

--- a/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
+++ b/datatypes/src/jvmMain/kotlin/at/asitplus/crypto/datatypes/JcaExtensions.kt
@@ -137,7 +137,7 @@ val CryptoSignature.jcaSignatureBytes: ByteArray
 fun CryptoSignature.Companion.parseFromJca(
     input: ByteArray,
     algorithm: X509SignatureAlgorithm
-): CryptoSignature.Defined =
+): CryptoSignature =
     if (algorithm.isEc)
         CryptoSignature.EC.decodeFromDer(input)
     else

--- a/datatypes/src/jvmTest/kotlin/ECCurveTest.kt
+++ b/datatypes/src/jvmTest/kotlin/ECCurveTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.shouldBe
  * Verifies the hard coded field modulus versus its functional definition
  * See https://www.secg.org/sec2-v2.pdf chapter 2
  */
-class ECCurveTest: FreeSpec({
+class ECCurveTest : FreeSpec({
     "SECP256 modulus correct" {
         ECCurve.SECP_256_R_1.modulus shouldBe
                 (2.toBigInteger().shl(223)
@@ -35,8 +35,8 @@ class ECCurveTest: FreeSpec({
 
     "Calculated parameters test" {
         ECCurve.SECP_256_R_1.scalarLength.bits shouldBe 256u
-        ECCurve.SECP_384_R_1.scalarLength.bits  shouldBe 384u
-        ECCurve.SECP_521_R_1.scalarLength.bits  shouldBe 521u
+        ECCurve.SECP_384_R_1.scalarLength.bits shouldBe 384u
+        ECCurve.SECP_521_R_1.scalarLength.bits shouldBe 521u
 
         ECCurve.SECP_256_R_1.scalarLength.bytes * 2u shouldBe 64u
         ECCurve.SECP_384_R_1.scalarLength.bytes * 2u shouldBe 96u

--- a/datatypes/src/jvmTest/kotlin/ECPointTest.kt
+++ b/datatypes/src/jvmTest/kotlin/ECPointTest.kt
@@ -1,11 +1,7 @@
 import at.asitplus.crypto.datatypes.ECCurve
 import at.asitplus.crypto.datatypes.ECPoint
-import at.asitplus.crypto.ecmath.plus
-import at.asitplus.crypto.ecmath.times
-import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import com.ionspin.kotlin.bignum.modular.ModularBigInteger
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
@@ -61,15 +57,15 @@ class ECPointTest : FreeSpec({
             shouldNotThrowAny { ECPoint.fromXY(curve, g.x.residue, (-g.y).residue) }
 
             fun wrongMod(v: ModularBigInteger) =
-                ModularBigInteger.creatorForModulo(v.modulus+1).fromBigInteger(v.residue)
+                ModularBigInteger.creatorForModulo(v.modulus + 1).fromBigInteger(v.residue)
 
             shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, wrongMod(g.x), g.y) }
             shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, g.x, wrongMod(g.y)) }
             shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, wrongMod(g.x), wrongMod(g.y)) }
 
-            shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, g.x+1, g.y) }
-            shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, g.x, g.y+1) }
-            shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, g.x.residue+1, g.y.residue) }
+            shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, g.x + 1, g.y) }
+            shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, g.x, g.y + 1) }
+            shouldThrow<IllegalArgumentException> { ECPoint.fromXY(curve, g.x.residue + 1, g.y.residue) }
 
             shouldNotThrowAny { ECPoint.fromUncompressed(curve, g.xBytes, g.yBytes) }
             shouldThrow<IllegalArgumentException> { ECPoint.fromUncompressed(curve, g.xBytes, byteArrayOf(0)) }

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Asn1EncodingTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Asn1EncodingTest.kt
@@ -127,7 +127,7 @@ class Asn1EncodingTest : FreeSpec({
         val instant = Clock.System.now()
 
         val sequence = Asn1.Sequence {
-            +Tagged(1u) { +Asn1Primitive(BERTags.BOOLEAN, byteArrayOf(0x00))            }
+            +Tagged(1u) { +Asn1Primitive(BERTags.BOOLEAN, byteArrayOf(0x00)) }
             +Asn1.Set {
                 +Asn1.Sequence {
                     +Asn1.SetOf {
@@ -144,7 +144,7 @@ class Asn1EncodingTest : FreeSpec({
             }
             +Null()
 
-           +ObjectIdentifier("1.2.603.624.97")
+            +ObjectIdentifier("1.2.603.624.97")
 
             +Utf8String("Foo")
             +PrintableString("Bar")

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/CryptoSignatureTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/CryptoSignatureTest.kt
@@ -57,7 +57,6 @@ class CryptoSignatureTest : FreeSpec({
                     ByteArray(66) { if (it == 65) 0x01 else 0x00 }
 
         val sig = CryptoSignature.EC.fromRS(r, s)
-        shouldThrow<IllegalStateException> { sig.rawByteArray }
 
         val sig1 = sig.guessCurve()
         sig1 shouldBe sig

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/CryptoSignatureTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/CryptoSignatureTest.kt
@@ -1,14 +1,12 @@
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
-import at.asitplus.crypto.datatypes.asn1.ensureSize
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.toBigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
 
 class CryptoSignatureTest : FreeSpec({
 
@@ -52,11 +50,11 @@ class CryptoSignatureTest : FreeSpec({
     }
 
     "Length handling & Curve guessing" {
-        val r = BigInteger.ONE.shl(ECCurve.SECP_521_R_1.scalarLength.bits.toInt()-1)
+        val r = BigInteger.ONE.shl(ECCurve.SECP_521_R_1.scalarLength.bits.toInt() - 1)
         val s = BigInteger.ONE
         val encoded =
             ByteArray(66) { if (it == 0) 0x01 else 0x00 } +
-            ByteArray(66) { if (it == 65) 0x01 else 0x00 }
+                    ByteArray(66) { if (it == 65) 0x01 else 0x00 }
 
         val sig = CryptoSignature.EC.fromRS(r, s)
         shouldThrow<IllegalStateException> { sig.rawByteArray }
@@ -84,7 +82,7 @@ class CryptoSignatureTest : FreeSpec({
         sig3.scalarByteLength shouldBe sig1.scalarByteLength
         sig3.rawByteArray shouldBe encoded
 
-        val r2 = BigInteger.ONE.shl(ECCurve.values().maxOf { it.scalarLength.bits }.toInt()+1)
+        val r2 = BigInteger.ONE.shl(ECCurve.values().maxOf { it.scalarLength.bits }.toInt() + 1)
         shouldThrow<IllegalArgumentException> { CryptoSignature.EC.fromRS(r2, s).guessCurve() }
     }
 })

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/DistinguishedNameTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/DistinguishedNameTest.kt
@@ -1,11 +1,7 @@
 package at.asitplus.crypto.datatypes
 
 import at.asitplus.crypto.datatypes.asn1.KnownOIDs
-import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.CommonName
-import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Country
-import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Organization
-import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.OrganizationalUnit
-import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.Other
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue.*
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Pkcs10CertificationRequestJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/Pkcs10CertificationRequestJvmTest.kt
@@ -1,15 +1,6 @@
 package at.asitplus.crypto.datatypes
 
-import at.asitplus.crypto.datatypes.asn1.Asn1Element
-import at.asitplus.crypto.datatypes.asn1.Asn1EncapsulatingOctetString
-import at.asitplus.crypto.datatypes.asn1.Asn1Primitive
-import at.asitplus.crypto.datatypes.asn1.Asn1Sequence
-import at.asitplus.crypto.datatypes.asn1.Asn1String
-import at.asitplus.crypto.datatypes.asn1.KnownOIDs
-import at.asitplus.crypto.datatypes.asn1.ObjectIdentifier
-import at.asitplus.crypto.datatypes.asn1.encodeToTlv
-import at.asitplus.crypto.datatypes.asn1.ensureSize
-import at.asitplus.crypto.datatypes.asn1.parse
+import at.asitplus.crypto.datatypes.asn1.*
 import at.asitplus.crypto.datatypes.pki.*
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
@@ -21,12 +12,7 @@ import org.bouncycastle.asn1.ASN1Integer
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers
 import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.asn1.x509.ExtendedKeyUsage
-import org.bouncycastle.asn1.x509.Extension
-import org.bouncycastle.asn1.x509.ExtensionsGenerator
-import org.bouncycastle.asn1.x509.KeyPurposeId
-import org.bouncycastle.asn1.x509.KeyUsage
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.asn1.x509.*
 import org.bouncycastle.operator.ContentSigner
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder
@@ -66,7 +52,17 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
 
         val tbsCsr = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf( RelativeDistinguishedName(listOf(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName))))),
+            subjectName = listOf(
+                RelativeDistinguishedName(
+                    listOf(
+                        AttributeTypeAndValue.CommonName(
+                            Asn1String.UTF8(
+                                commonName
+                            )
+                        )
+                    )
+                )
+            ),
             publicKey = cryptoPublicKey
         )
         val signed = Signature.getInstance(signatureAlgorithm.jcaName).apply {
@@ -107,7 +103,17 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
             .build(contentSigner)
         val tbsCsr = TbsCertificationRequest(
             version = 0,
-            subjectName = listOf(RelativeDistinguishedName( listOf(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName))))),
+            subjectName = listOf(
+                RelativeDistinguishedName(
+                    listOf(
+                        AttributeTypeAndValue.CommonName(
+                            Asn1String.UTF8(
+                                commonName
+                            )
+                        )
+                    )
+                )
+            ),
             publicKey = cryptoPublicKey,
             attributes = listOf(
                 Pkcs10CertificationRequestAttribute(KnownOIDs.keyUsage, Asn1Element.parse(keyUsage.encoded)),
@@ -127,8 +133,13 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
         val jvmEncoded = bcCsr.encoded
         // CSR will never entirely match because of randomness in ECDSA signature
         //kotlinEncoded shouldBe jvmEncoded
-        withClue("kotlinEncoded: ${csr.encodeToTlv().toDerHexString()}, jvmEncoded: ${bcCsr.encoded.toHexString(
-            HexFormat.UpperCase)}")
+        withClue(
+            "kotlinEncoded: ${csr.encodeToTlv().toDerHexString()}, jvmEncoded: ${
+                bcCsr.encoded.toHexString(
+                    HexFormat.UpperCase
+                )
+            }"
+        )
         { kotlinEncoded.drop(6).take(172) shouldBe jvmEncoded.drop(6).take(172) }
 
         val parsedFromKotlinCsr = PKCS10CertificationRequest(kotlinEncoded)
@@ -196,8 +207,8 @@ class Pkcs10CertificationRequestJvmTest : FreeSpec({
 
     "CSR can be parsed" {
         val ecPublicKey = keyPair.public as ECPublicKey
-        val keyX = ecPublicKey.w.affineX.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
-        val keyY = ecPublicKey.w.affineY.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
+        val keyX = ecPublicKey.w.affineX.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
+        val keyY = ecPublicKey.w.affineY.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
 
         // create CSR with bouncycastle
         val commonName = "DefaultCryptoService"

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertParserTest.kt
@@ -72,7 +72,7 @@ class X509CertParserTest : FreeSpec({
             ((kotlin.runCatching {
                 File("/etc/ssl/certs/ca-certificates.crt").readText().split(Regex.fromLiteral("-\n-"))
             }.getOrNull() ?: emptyList())
-            + (macosCertsPem?.split(Regex.fromLiteral("-\n-")) ?: emptyList())
+                    + (macosCertsPem?.split(Regex.fromLiteral("-\n-")) ?: emptyList())
                     )
                 .mapNotNull {
                     var pem = if (it.startsWith("-----")) it else "-$it"
@@ -91,11 +91,13 @@ class X509CertParserTest : FreeSpec({
         println("Got ${certs.size} discrete certs and ${pemEncodeCerts.size} from trust store (${uniqueCerts.size} unique ones)")
 
         withData(
-            nameFn = { it.subjectX500Principal.name.let { name->
-                if(name.isBlank() || name.isEmpty())
-                    it.serialNumber.toString(16)
+            nameFn = {
+                it.subjectX500Principal.name.let { name ->
+                    if (name.isBlank() || name.isEmpty())
+                        it.serialNumber.toString(16)
                     else name
-            } },
+                }
+            },
             uniqueCerts.sortedBy { it.subjectX500Principal.name }) { crt ->
             val parsed = X509Certificate.decodeFromTlv(Asn1Element.parse(crt.encoded) as Asn1Sequence)
             val own = parsed.encodeToDer()

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
@@ -83,8 +83,7 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
         }.sign()
-        val test =
-            (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val test =            CryptoSignature.decodeFromDer(signed)
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         val kotlinEncoded = x509Certificate.encodeToDer()
@@ -130,8 +129,7 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
         }.sign()
-        val test =
-            (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val test = CryptoSignature.decodeFromDer(signed)
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         repeat(500) {

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
@@ -1,5 +1,6 @@
 package at.asitplus.crypto.datatypes
 
+import at.asitplus.crypto.datatypes.CryptoPublicKey.EC.Companion.fromUncompressed
 import at.asitplus.crypto.datatypes.asn1.*
 import at.asitplus.crypto.datatypes.pki.*
 import io.kotest.core.spec.style.FreeSpec
@@ -82,7 +83,8 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
         }.sign()
-        val test = (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val test =
+            (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         val kotlinEncoded = x509Certificate.encodeToDer()
@@ -128,10 +130,16 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
         }.sign()
-        val test = (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val test =
+            (CryptoSignature.decodeFromDer(signed) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
-        repeat(500) { launch { x509Certificate.toJcaCertificate().getOrThrow().toKmpCertificate().getOrThrow().encodeToDer() shouldBe x509Certificate.encodeToDer() } }
+        repeat(500) {
+            launch {
+                x509Certificate.toJcaCertificate().getOrThrow().toKmpCertificate().getOrThrow()
+                    .encodeToDer() shouldBe x509Certificate.encodeToDer()
+            }
+        }
     }
 
     "Certificate can be parsed" {
@@ -182,9 +190,9 @@ class X509CertificateJvmTest : FreeSpec({
 
     "Certificate can be parsed to tree" {
         val ecPublicKey = keyPair.public as ECPublicKey
-        val keyX = ecPublicKey.w.affineX.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
-        val keyY = ecPublicKey.w.affineY.toByteArray().ensureSize(ecCurve.coordinateLengthBytes)
-        val cryptoPublicKey = CryptoPublicKey.EC(curve = ecCurve, x = keyX, y = keyY)
+        val keyX = ecPublicKey.w.affineX.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
+        val keyY = ecPublicKey.w.affineY.toByteArray().ensureSize(ecCurve.coordinateLength.bytes)
+        val cryptoPublicKey = fromUncompressed(curve = ecCurve, x = keyX, y = keyY)
 
         // create certificate with bouncycastle
         val notBeforeDate = Date.from(Instant.now())
@@ -348,9 +356,12 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate3.encodeToTlv().derEncoded)
         }.sign()
-        val signature1 = (CryptoSignature.decodeFromDer(signed1) as  CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
-        val signature2 = (CryptoSignature.decodeFromDer(signed2) as  CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
-        val signature3 = (CryptoSignature.decodeFromDer(signed3) as  CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_521_R_1)
+        val signature1 =
+            (CryptoSignature.decodeFromDer(signed1) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val signature2 =
+            (CryptoSignature.decodeFromDer(signed2) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
+        val signature3 =
+            (CryptoSignature.decodeFromDer(signed3) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_521_R_1)
         val x509Certificate1 = X509Certificate(tbsCertificate1, signatureAlgorithm256, signature1)
         val x509Certificate2 = X509Certificate(tbsCertificate2, signatureAlgorithm256, signature2)
         val x509Certificate3 = X509Certificate(tbsCertificate3, signatureAlgorithm512, signature3)

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/X509CertificateJvmTest.kt
@@ -83,7 +83,7 @@ class X509CertificateJvmTest : FreeSpec({
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
         }.sign()
-        val test =            CryptoSignature.decodeFromDer(signed)
+        val test = CryptoSignature.decodeFromDer(signed)
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         val kotlinEncoded = x509Certificate.encodeToDer()

--- a/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/ecmath/ECMathTest.kt
+++ b/datatypes/src/jvmTest/kotlin/at/asitplus/crypto/ecmath/ECMathTest.kt
@@ -20,12 +20,17 @@ import kotlin.random.Random
 
 private fun ECCurve.randomScalar(): ModularBigInteger =
     scalarCreator.fromBigInteger(BigInteger.fromByteArray(Random.nextBytes(scalarLength.bytes.toInt()), Sign.POSITIVE))
+
 private fun ECCurve.randomPoint(): ECPoint =
-    generateSequence { runCatching {
-        ECPoint.fromCompressed(
-            this, Random.nextBytes(coordinateLength.bytes.toInt()), Random.nextBoolean())
-    }}.firstNotNullOf { it.getOrNull() }
-class ECMathTest: FreeSpec({
+    generateSequence {
+        runCatching {
+            ECPoint.fromCompressed(
+                this, Random.nextBytes(coordinateLength.bytes.toInt()), Random.nextBoolean()
+            )
+        }
+    }.firstNotNullOf { it.getOrNull() }
+
+class ECMathTest : FreeSpec({
     "Assumption: All implemented curves are prime order Weierstrass curves with a = -3" - {
         withData(ECCurve.entries) { curve ->
             // if new curves are ever added that violate this assumption,
@@ -38,26 +43,27 @@ class ECMathTest: FreeSpec({
         withData(ECCurve.entries) { curve ->
             withData(generateSequence {
                 Triple(curve.randomPoint(), curve.randomPoint(), curve.randomPoint())
-            }.take(50)) { (a,b,c) ->
-                a+b shouldBe b+a
-                (a+b)+c shouldBe a+(b+c)
-                a+(-a) shouldBe curve.IDENTITY
-                a+b+(-a) shouldBe b
-                (-c)+a+b+c shouldBe a+b
-                (-b)+a shouldBe a-b
+            }.take(50)) { (a, b, c) ->
+                a + b shouldBe b + a
+                (a + b) + c shouldBe a + (b + c)
+                a + (-a) shouldBe curve.IDENTITY
+                a + b + (-a) shouldBe b
+                (-c) + a + b + c shouldBe a + b
+                (-b) + a shouldBe a - b
             }
         }
     }
     "Multiplication: axioms" - {
         withData(ECCurve.entries) { curve ->
-            withData(nameFn = { (a,b,x,y) -> "(a=$a, b=$b, x=$x, y=$y)" },
-            generateSequence {
-                Quadruple(curve.randomScalar(), curve.randomScalar(), curve.randomPoint(), curve.randomPoint())
-            }.take(10)) { (a,b,x,y) ->
+            withData(nameFn = { (a, b, x, y) -> "(a=$a, b=$b, x=$x, y=$y)" },
+                generateSequence {
+                    Quadruple(curve.randomScalar(), curve.randomScalar(), curve.randomPoint(), curve.randomPoint())
+                }.take(10)
+            ) { (a, b, x, y) ->
                 0 * x shouldBe curve.IDENTITY
-                a * (x+y) shouldBe (a*x) + (a*y)
-                (a*b) * x shouldBe a * (b*x)
-                b.inverse()*(a*(b*x)) shouldBe a*x
+                a * (x + y) shouldBe (a * x) + (a * y)
+                (a * b) * x shouldBe a * (b * x)
+                b.inverse() * (a * (b * x)) shouldBe a * x
             }
         }
     }
@@ -65,7 +71,9 @@ class ECMathTest: FreeSpec({
     "Multiplication: PaI test suite" - {
         withData(nameFn = { (curve, _) -> curve.name },
             sequence {
-            yield(Pair(ECCurve.SECP_256_R_1, """
+                yield(
+                    Pair(
+                        ECCurve.SECP_256_R_1, """
                 k = 1
                 x = 6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296
                 y = 4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5
@@ -274,9 +282,13 @@ class ECMathTest: FreeSpec({
                 k = 115792089210356248762697446949407573529996955224135760342422259061068512044368
                 x = 6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296
                 y = B01CBD1C01E58065711814B583F061E9D431CCA994CEA1313449BF97C840AE0A
-            """.trimIndent()))
+            """.trimIndent()
+                    )
+                )
 
-            yield(Pair(ECCurve.SECP_384_R_1, """
+                yield(
+                    Pair(
+                        ECCurve.SECP_384_R_1, """
                 k = 1
                 x = AA87CA22BE8B05378EB1C71EF320AD746E1D3B628BA79B9859F741E082542A385502F25DBF55296C3A545E3872760AB7
                 y = 3617DE4A96262C6F5D9E98BF9292DC29F8F41DBD289A147CE9DA3113B5F0B8C00A60B1CE1D7E819D7A431D7C90EA0E5F
@@ -484,9 +496,13 @@ class ECMathTest: FreeSpec({
                 k = 39402006196394479212279040100143613805079739270465446667946905279627659399113263569398956308152294913554433653942642
                 x = AA87CA22BE8B05378EB1C71EF320AD746E1D3B628BA79B9859F741E082542A385502F25DBF55296C3A545E3872760AB7
                 y = C9E821B569D9D390A26167406D6D23D6070BE242D765EB831625CEEC4A0F473EF59F4E30E2817E6285BCE2846F15F1A0
-            """.trimIndent()))
+            """.trimIndent()
+                    )
+                )
 
-            yield(Pair(ECCurve.SECP_521_R_1, """
+                yield(
+                    Pair(
+                        ECCurve.SECP_521_R_1, """
                 k = 1
                 x = 00C6858E06B70404E9CD9E3ECB662395B4429C648139053FB521F828AF606B4D3DBAA14B5E77EFE75928FE1DC127A2FFA8DE3348B3C1856A429BF97E7E31C2E5BD66
                 y = 011839296A789A3BC0045C8A5FB42C7D1BD998F54449579B446817AFBD17273E662C97EE72995EF42640C550B9013FAD0761353C7086A272C24088BE94769FD16650
@@ -694,17 +710,20 @@ class ECMathTest: FreeSpec({
                 k = 6864797660130609714981900799081393217269435300143305409394463459185543183397655394245057746333217197532963996371363321113864768612440380340372808892707005448
                 x = 00C6858E06B70404E9CD9E3ECB662395B4429C648139053FB521F828AF606B4D3DBAA14B5E77EFE75928FE1DC127A2FFA8DE3348B3C1856A429BF97E7E31C2E5BD66
                 y = 00E7C6D6958765C43FFBA375A04BD382E426670ABBB6A864BB97E85042E8D8C199D368118D66A10BD9BF3AAF46FEC052F89ECAC38F795D8D3DBF77416B89602E99AF
-            """.trimIndent()))
-        }) { (curve, testInfo) ->
+            """.trimIndent()
+                    )
+                )
+            }) { (curve, testInfo) ->
             val pattern = Regex("k = ([0-9]+)\\s+x = ([0-9A-F]+)\\s+y = ([0-9A-F]+)")
-            withData(nameFn = { (k,_,_) -> "k = $k" },
+            withData(nameFn = { (k, _, _) -> "k = $k" },
                 pattern.findAll(testInfo).map {
                     Triple(
                         BigInteger.parseString(it.groupValues[1], 10),
                         BigInteger.parseString(it.groupValues[2], 16),
-                        BigInteger.parseString(it.groupValues[3], 16))
+                        BigInteger.parseString(it.groupValues[3], 16)
+                    )
                 }
-            ) { (k,x,y) ->
+            ) { (k, x, y) ->
                 val ourResult = curve.generator.times(k).normalize()
                 ourResult.x.residue shouldBe x
                 ourResult.y.residue shouldBe y
@@ -722,8 +741,8 @@ class ECMathTest: FreeSpec({
                 val w = (keyPair.public as ECPublicKey).w.let {
                     ECPoint.fromUncompressed(curve, it.affineX.toByteArray(), it.affineY.toByteArray())
                 }
-                Pair(s,w)
-            }.take(10)) { (s,w) ->
+                Pair(s, w)
+            }.take(10)) { (s, w) ->
                 (s * curve.generator) shouldBe w
             }
         }

--- a/datatypes/src/jvmTest/kotlin/dep_tests/BigIntegerTest.kt
+++ b/datatypes/src/jvmTest/kotlin/dep_tests/BigIntegerTest.kt
@@ -4,10 +4,7 @@ import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import com.ionspin.kotlin.bignum.integer.base63.toJavaBigInteger
 import com.ionspin.kotlin.bignum.modular.ModularBigInteger
-import io.kotest.assertions.withClue
-import io.kotest.core.names.TestName
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlin.random.Random

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion = 3.2.0
+artifactVersion = 3.2.0-SNAPSHOT
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion = 3.2.0-SNAPSHOT
+artifactVersion = 3.2.0
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ okio = "3.5.0"
 bignum = "0.3.10-SNAPSHOT"
 jose = "9.31"
 kotlinpoet = "1.16.0"
+kmmresult = "1.6.2"
 
 [libraries]
 base16 = { group = "io.matthewnelson.kotlin-components", name = "encoding-base16", version.ref = "encoding" }


### PR DESCRIPTION
Proper version of #82 going into development.  
Once merged, will prepare a release.

Changes the following:

 * Rename `toCryptoAlgorithm` to `toX509SignatureAlgorithm` accordingly
 * Rework CryptoSignature to two-dimensional interface:
   * CryptoSignature <- {EC <- {IndefiniteLength, DefiniteLength}, RsaOrHmac}
    * CryptoSignature <- {Defined <- {Ill <- EC.IndefiniteLength, Well <- {EC.DefiniteLength, RsaOrHmac}}

This finally makes it possible to get a common ground to encode RSA/HMAC and EC signatures for COSE and JWS, without having to jump through hoops. The effect of this can be seen in [the corresponding  VC Lib PR](https://github.com/a-sit-plus/kmm-vc-library/pull/83).