### PR TITLE
Tmp/json key id on init

### DIFF
--- a/datatypes-cose/src/jvmTest/kotlin/ConversionTests.kt
+++ b/datatypes-cose/src/jvmTest/kotlin/ConversionTests.kt
@@ -1,10 +1,27 @@
 import at.asitplus.KmmResult
+import at.asitplus.crypto.datatypes.CryptoPublicKey
+import at.asitplus.crypto.datatypes.CryptoSignature
+import at.asitplus.crypto.datatypes.X509SignatureAlgorithm
+import at.asitplus.crypto.datatypes.asn1.Asn1String
+import at.asitplus.crypto.datatypes.asn1.Asn1Time
 import at.asitplus.crypto.datatypes.cose.CoseAlgorithm
 import at.asitplus.crypto.datatypes.cose.toCoseAlgorithm
+import at.asitplus.crypto.datatypes.cose.toCoseKey
+import at.asitplus.crypto.datatypes.fromJcaPublicKey
+import at.asitplus.crypto.datatypes.pki.AttributeTypeAndValue
+import at.asitplus.crypto.datatypes.pki.RelativeDistinguishedName
+import at.asitplus.crypto.datatypes.pki.TbsCertificate
+import at.asitplus.crypto.datatypes.pki.X509Certificate
 import at.asitplus.crypto.datatypes.toX509SignatureAlgorithm
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.Sign
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import kotlinx.datetime.Clock
+import java.security.KeyPairGenerator
+import java.security.interfaces.ECPublicKey
+import kotlin.random.Random
 
 infix fun <T> KmmResult<T>.shouldSucceedWith(b: T) : T =
     (this.getOrThrow() shouldBe b)
@@ -23,4 +40,17 @@ class ConversionTests : FreeSpec({
             }
         }
     }
+
+    "Regression test: COSE key (no keyId) -> CryptoPublicKey -> COSE key (no keyId)" {
+        val key = randomPublicKey().toCoseKey().getOrThrow()
+        key.keyId shouldBe null
+        val cpk = key.toCryptoPublicKey().getOrThrow()
+        cpk.toCoseKey().getOrThrow().keyId shouldBe null
+        val kid = Random.nextBytes(16)
+        cpk.toCoseKey(keyId = kid).getOrThrow().keyId shouldBe kid
+    }
 })
+
+private fun randomPublicKey() =
+    CryptoPublicKey.EC.fromJcaPublicKey(KeyPairGenerator.getInstance("EC").apply { initialize(256) }
+        .genKeyPair().public as ECPublicKey).getOrThrow()

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -288,7 +288,7 @@ data class JsonWebKey(
                     curve = curve ?: throw IllegalArgumentException("Missing or invalid curve"),
                     x = x ?: throw IllegalArgumentException("Missing x-coordinate"),
                     y = y ?: throw IllegalArgumentException("Missing y-coordinate")
-                ).apply { jwkId = identifier }
+                ).apply { jwkId = keyId }
             }
 
             JwkType.RSA -> {
@@ -296,7 +296,7 @@ data class JsonWebKey(
                     n = n ?: throw IllegalArgumentException("Missing modulus n"),
                     e = e?.let { bytes -> Int.decodeFromDer(bytes) }
                         ?: throw IllegalArgumentException("Missing or invalid exponent e")
-                ).apply { jwkId = identifier }
+                ).apply { jwkId = keyId }
             }
 
             else -> throw IllegalArgumentException("Illegal key type")
@@ -324,12 +324,12 @@ data class JsonWebKey(
 /**
  * Converts a [CryptoPublicKey] to a [JsonWebKey]
  */
-fun CryptoPublicKey.toJsonWebKey(): JsonWebKey =
+fun CryptoPublicKey.toJsonWebKey(keyId: String? = this.jwkId): JsonWebKey =
     when (this) {
         is CryptoPublicKey.EC ->
             JsonWebKey(
                 type = JwkType.EC,
-                keyId = jwkId,
+                keyId = keyId,
                 curve = curve,
                 x = xBytes,
                 y = yBytes
@@ -339,7 +339,7 @@ fun CryptoPublicKey.toJsonWebKey(): JsonWebKey =
         is CryptoPublicKey.Rsa ->
             JsonWebKey(
                 type = JwkType.RSA,
-                keyId = jwkId,
+                keyId = keyId,
                 n = n,
                 e = e.encodeToByteArray()
             )

--- a/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
+++ b/datatypes-jws/src/jvmTest/kotlin/at/asitplus/crypto/datatypes/jws/JwkTest.kt
@@ -14,6 +14,7 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.property.azstring
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Clock
 import java.security.KeyPairGenerator
@@ -109,6 +110,15 @@ class JwkTest : FreeSpec({
         val parsed = JsonWebKey.deserialize(jwk.serialize()).getOrThrow()
 
         parsed shouldBe jwk
+    }
+
+    "Regression test: JWK (no keyId) -> CryptoPublicKey -> JWK (no keyId)" {
+        val key = randomCertificate().publicKey.toJsonWebKey()
+        key.keyId shouldBe null
+        val cpk = key.toCryptoPublicKey().getOrThrow()
+        cpk.toJsonWebKey().keyId shouldBe null
+        val kid = Random.azstring(16)
+        cpk.toJsonWebKey(keyId = kid).keyId shouldBe kid
     }
 })
 


### PR DESCRIPTION
When a JsonWebKey is created from a CryptopublicKey which in turn was created by a keyPair it does not have a keyId. However if we transform this JsonWebKey back to a CryptoPublicKey the identifier gets saved to keyId and if we then transform it back again to JsonWebKey it now has a keyid -> the previous identifier.

As an easy fix I propose this change, however other ideas are welcome.