### PR TITLE
Add `SpecializedCryptoPublicKey` interface

### DIFF
--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKey.kt
@@ -5,6 +5,7 @@ import at.asitplus.KmmResult.Companion.failure
 import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.SignatureAlgorithm
+import at.asitplus.crypto.datatypes.SpecializedCryptoPublicKey
 import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
 import at.asitplus.crypto.datatypes.cose.CoseKey.Companion.deserialize
 import at.asitplus.crypto.datatypes.cose.CoseKeySerializer.CompressedCompoundCoseKeySerialContainer
@@ -51,7 +52,7 @@ data class CoseKey(
     val operations: Array<CoseKeyOperation>? = null,
     val baseIv: ByteArray? = null,
     val keyParams: CoseKeyParams?,
-) {
+) : SpecializedCryptoPublicKey {
     override fun toString(): String {
         return "CoseKey(type=$type," +
                 " keyId=${keyId?.encodeToString(Base16Strict)}," +
@@ -101,7 +102,7 @@ data class CoseKey(
      * or the first error. More details in either [CoseKeyParams.RsaParams.toCryptoPublicKey],
      * [CoseKeyParams.EcYBoolParams.toCryptoPublicKey] or [CoseKeyParams.EcYByteArrayParams.toCryptoPublicKey]
      */
-    fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> =
+    override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> =
         keyParams?.toCryptoPublicKey()?.map { it.coseKid = this.keyId; it }
             ?: failure(IllegalArgumentException("No public key parameters!"))
 

--- a/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
+++ b/datatypes-cose/src/commonMain/kotlin/at/asitplus/crypto/datatypes/cose/CoseKeyParams.kt
@@ -4,14 +4,13 @@ import at.asitplus.KmmResult
 import at.asitplus.KmmResult.Companion.failure
 import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
+import at.asitplus.crypto.datatypes.SpecializedCryptoPublicKey
 import at.asitplus.crypto.datatypes.asn1.decodeFromDer
 
 /**
  * Wrapper to handle parameters for different COSE public key types.
  */
-sealed class CoseKeyParams {
-
-    abstract fun toCryptoPublicKey(): KmmResult<CryptoPublicKey>
+sealed class CoseKeyParams : SpecializedCryptoPublicKey {
 
     /**
      * COSE EC public key parameters

--- a/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
+++ b/datatypes-jws/src/commonMain/kotlin/at/asitplus/crypto/datatypes/jws/JsonWebKey.kt
@@ -7,6 +7,7 @@ import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.CryptoPublicKey.EC.Companion.fromUncompressed
 import at.asitplus.crypto.datatypes.ECCurve
+import at.asitplus.crypto.datatypes.SpecializedCryptoPublicKey
 import at.asitplus.crypto.datatypes.asn1.decodeFromDer
 import at.asitplus.crypto.datatypes.asn1.encodeToByteArray
 import at.asitplus.crypto.datatypes.io.Base64UrlStrict
@@ -180,7 +181,7 @@ data class JsonWebKey(
     @SerialName("x5t#S256")
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val certificateSha256Thumbprint: ByteArray? = null,
-) {
+) : SpecializedCryptoPublicKey {
 
     /**
      * Thumbprint in the form of `urn:ietf:params:oauth:jwk-thumbprint:sha256:DEADBEEF`
@@ -193,15 +194,6 @@ data class JsonWebKey(
     }
 
     fun serialize() = jsonSerializer.encodeToString(this)
-
-    fun equalsCryptographically(other: JsonWebKey) =
-        curve == other.curve &&
-                type == other.type &&
-                x.contentEquals(other.x) &&
-                y.contentEquals(other.y) &&
-                n.contentEquals(other.n) &&
-                e.contentEquals(other.e) &&
-                k.contentEquals(other.k)
 
     val didEncoded: String? by lazy { toCryptoPublicKey().getOrNull()?.didEncoded }
 
@@ -292,7 +284,7 @@ data class JsonWebKey(
      * @return a KmmResult wrapped [CryptoPublicKey] equivalent if conversion is possible
      * (i.e. if all key params are set), or the first error.
      */
-    fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> = catching {
+    override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> = catching {
         when (type) {
             JwkType.EC -> {
                 fromUncompressed(


### PR DESCRIPTION
See discussion in #96, this allows comparing `CoseKey` to `JsonWebKey`, or to `CryptoPublicKey`, or to anything else we decide to add in the future.