### PR TITLE
3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,3 +167,8 @@
 
 **Fixes**
  * Correct serialization of COSE signature structures
+
+### 3.2.2
+* KmmResult 1.7.0
+* Bignum 0.3.10 stable
+* okio 3.9.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 plugins {
-    id("at.asitplus.gradle.conventions") version "2.0.0+20240610"
+    id("at.asitplus.gradle.conventions") version "2.0.0+20240717"
 }
 group = "at.asitplus.crypto"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion = 3.2.1
+artifactVersion = 3.2.2
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,9 @@
 [versions]
 encoding = "1.2.3"
-okio = "3.5.0"
-bignum = "0.3.10-SNAPSHOT"
+okio = "3.9.0"
+bignum = "0.3.10"
 jose = "9.31"
 kotlinpoet = "1.16.0"
-kmmresult = "1.6.2"
 
 [libraries]
 base16 = { group = "io.matthewnelson.kotlin-components", name = "encoding-base16", version.ref = "encoding" }


### PR DESCRIPTION
* KmmResult 1.7.0
* Bignum 0.3.10 stable
* okio 3.9.0

Should then also be cherry-picked to development
